### PR TITLE
Enable nullable globally and fix issues

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <langversion>10.0</langversion>
+  </PropertyGroup>
+
+</Project>

--- a/src/Block.cs
+++ b/src/Block.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Runtime.Serialization;
 
 namespace Ipfs.Http
@@ -11,11 +12,11 @@ namespace Ipfs.Http
 
         /// <inheritdoc />
         [DataMember]
-        public Cid Id { get; set; }
+        public Cid? Id { get; set; }
 
         /// <inheritdoc />
         [DataMember]
-        public byte[] DataBytes { get; set; }
+        public byte[] DataBytes { get; set; } = Array.Empty<byte>();
 
         /// <inheritdoc />
         public Stream DataStream

--- a/src/Block.cs
+++ b/src/Block.cs
@@ -15,7 +15,8 @@ namespace Ipfs.Http
         [DataMember]
         public Cid Id
         {
-            get => id ?? throw new InvalidDataException("Value mus be initialized");
+            get => id ?? throw new InvalidDataException("Value must be initialized");
+
             set => id = value;
         }
 

--- a/src/Block.cs
+++ b/src/Block.cs
@@ -8,24 +8,23 @@ namespace Ipfs.Http
     [DataContract]
     public class Block : IDataBlock
     {
-        long? size;
+        private long? size;
+        private Cid? id;
 
         /// <inheritdoc />
         [DataMember]
-        public Cid? Id { get; set; }
+        public Cid Id
+        {
+            get => id ?? throw new InvalidDataException("Value mus be initialized");
+            set => id = value;
+        }
 
         /// <inheritdoc />
         [DataMember]
         public byte[] DataBytes { get; set; } = Array.Empty<byte>();
 
         /// <inheritdoc />
-        public Stream DataStream
-        {
-            get
-            {
-                return new MemoryStream(DataBytes, false);
-            }
-        }
+        public Stream DataStream => new MemoryStream(DataBytes, false);
 
         /// <inheritdoc />
         [DataMember]
@@ -44,7 +43,5 @@ namespace Ipfs.Http
                 size = value;
             }
         }
-
     }
-
 }

--- a/src/CoreApi/BitswapApi.cs
+++ b/src/CoreApi/BitswapApi.cs
@@ -9,22 +9,22 @@ namespace Ipfs.Http
 {
     class BitswapApi : IBitswapApi
     {
-        IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal BitswapApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public Task<IDataBlock> GetAsync(Cid id, CancellationToken cancel = default(CancellationToken))
+        public Task<IDataBlock> GetAsync(Cid id, CancellationToken cancel = default)
         {
             return ipfs.Block.GetAsync(id, cancel);
         }
 
-        public async Task<IEnumerable<Cid>> WantsAsync(MultiHash peer = null, CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<Cid>> WantsAsync(MultiHash? peer = null, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("bitswap/wantlist", cancel, peer?.ToString());
-            var keys = (JArray)(JObject.Parse(json)["Keys"]);
+            var keys = (JArray?)(JObject.Parse(json)["Keys"]);
             // https://github.com/ipfs/go-ipfs/issues/5077
             return keys
                 .Select(k =>
@@ -36,23 +36,22 @@ namespace Ipfs.Http
                 });
         }
 
-        public async Task UnwantAsync(Cid id, CancellationToken cancel = default(CancellationToken))
+        public async Task UnwantAsync(Cid id, CancellationToken cancel = default)
         {
             await ipfs.DoCommandAsync("bitswap/unwant", cancel, id);
         }
 
-        public async Task<BitswapLedger> LedgerAsync(Peer peer, CancellationToken cancel = default(CancellationToken))
+        public async Task<BitswapLedger> LedgerAsync(Peer peer, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("bitswap/ledger", cancel, peer.Id.ToString());
             var o = JObject.Parse(json);
             return new BitswapLedger
             {
-                Peer = (string)o["Peer"],
-                DataReceived = (ulong)o["Sent"],
-                DataSent = (ulong)o["Recv"],
-                BlocksExchanged = (ulong)o["Exchanged"]
+                Peer = (string?)o["Peer"],
+                DataReceived = (ulong?)o["Sent"] ?? 0,
+                DataSent = (ulong?)o["Recv"] ?? 0,
+                BlocksExchanged = (ulong?)o["Exchanged"] ?? 0,
             };
         }
     }
-
 }

--- a/src/CoreApi/BitswapApi.cs
+++ b/src/CoreApi/BitswapApi.cs
@@ -32,7 +32,7 @@ namespace Ipfs.Http
                     if (k.Type == JTokenType.String)
                         return Cid.Decode(k.ToString());
                     var obj = (JObject)k;
-                    return Cid.Decode(obj["/"].ToString());
+                    return Cid.Decode(obj["/"]!.ToString());
                 });
         }
 
@@ -43,11 +43,11 @@ namespace Ipfs.Http
 
         public async Task<BitswapLedger> LedgerAsync(Peer peer, CancellationToken cancel = default)
         {
-            var json = await ipfs.DoCommandAsync("bitswap/ledger", cancel, peer.Id.ToString());
+            var json = await ipfs.DoCommandAsync("bitswap/ledger", cancel, peer.Id?.ToString());
             var o = JObject.Parse(json);
             return new BitswapLedger
             {
-                Peer = (string?)o["Peer"],
+                Peer = (string)o["Peer"]!,
                 DataReceived = (ulong?)o["Sent"] ?? 0,
                 DataSent = (ulong?)o["Recv"] ?? 0,
                 BlocksExchanged = (ulong?)o["Exchanged"] ?? 0,

--- a/src/CoreApi/BlockApi.cs
+++ b/src/CoreApi/BlockApi.cs
@@ -46,7 +46,7 @@ namespace Ipfs.Http
             }
             var json = await ipfs.UploadAsync("block/put", cancel, data, options.ToArray());
             var info = JObject.Parse(json);
-            Cid cid = (string?)info["Key"];
+            Cid cid = (string)info["Key"]!;
 
             if (pin)
             {
@@ -75,7 +75,7 @@ namespace Ipfs.Http
             }
             var json = await ipfs.UploadAsync("block/put", cancel, data, name: null, options.ToArray());
             var info = JObject.Parse(json);
-            Cid cid = (string?)info["Key"];
+            Cid cid = (string)info["Key"]!;
 
             if (pin)
             {
@@ -92,7 +92,7 @@ namespace Ipfs.Http
             return new Block
             {
                 Size = (long?)info["Size"] ?? 0,
-                Id = (string?)info["Key"]
+                Id = (string)info["Key"]!
             };
         }
 
@@ -105,7 +105,7 @@ namespace Ipfs.Http
             var error = (string?)result["Error"];
             if (error is not null)
                 throw new HttpRequestException(error);
-            return (Cid)(string?)result["Hash"];
+            return (Cid)(string)result["Hash"]!;
         }
     }
 }

--- a/src/CoreApi/BlockRepositoryApi.cs
+++ b/src/CoreApi/BlockRepositoryApi.cs
@@ -29,11 +29,11 @@ namespace Ipfs.Http
             await ipfs.DoCommandAsync("repo/verify", cancel);
         }
 
-        public async Task<string?> VersionAsync(CancellationToken cancel = default)
+        public async Task<string> VersionAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("repo/version", cancel);
             var info = JObject.Parse(json);
-            return (string?)info["Version"];
+            return (string)info["Version"]!;
         }
     }
 }

--- a/src/CoreApi/BlockRepositoryApi.cs
+++ b/src/CoreApi/BlockRepositoryApi.cs
@@ -7,33 +7,33 @@ namespace Ipfs.Http
 {
     class BlockRepositoryApi : IBlockRepositoryApi
     {
-        IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal BlockRepositoryApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public async Task RemoveGarbageAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task RemoveGarbageAsync(CancellationToken cancel = default)
         {
             await ipfs.DoCommandAsync("repo/gc", cancel);
         }
 
-        public Task<RepositoryData> StatisticsAsync(CancellationToken cancel = default(CancellationToken))
+        public Task<RepositoryData> StatisticsAsync(CancellationToken cancel = default)
         {
             return ipfs.DoCommandAsync<RepositoryData>("repo/stat", cancel);
         }
 
-        public async Task VerifyAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task VerifyAsync(CancellationToken cancel = default)
         {
             await ipfs.DoCommandAsync("repo/verify", cancel);
         }
 
-        public async Task<string> VersionAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task<string?> VersionAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("repo/version", cancel);
             var info = JObject.Parse(json);
-            return (string)info["Version"];
+            return (string?)info["Version"];
         }
     }
 }

--- a/src/CoreApi/BootstrapApi.cs
+++ b/src/CoreApi/BootstrapApi.cs
@@ -23,25 +23,37 @@ namespace Ipfs.Http
             var a = addrs.FirstOrDefault();
             if (a is null)
                 return null;
-            return new MultiAddress((string?)a);
+            return new MultiAddress((string)a!);
         }
 
         public async Task<IEnumerable<MultiAddress>> AddDefaultsAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("bootstrap/add/default", cancel);
             var addrs = (JArray?)(JObject.Parse(json)["Peers"]);
+            if (addrs is null)
+            {
+                return Enumerable.Empty<MultiAddress>();
+            }
+
             return addrs
-                .Select(a => MultiAddress.TryCreate((string?)a))
-                .Where(ma => ma is not null);
+                .Select(a => MultiAddress.TryCreate((string)a!))
+                .Where(ma => ma is not null)
+                .Cast<MultiAddress>();
         }
 
         public async Task<IEnumerable<MultiAddress>> ListAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("bootstrap/list", cancel);
             var addrs = (JArray?)(JObject.Parse(json)["Peers"]);
+            if (addrs is null)
+            {
+                return Enumerable.Empty<MultiAddress>();
+            }
+
             return addrs
-                .Select(a => MultiAddress.TryCreate((string?)a))
-                .Where(ma => ma is not null);
+                .Select(a => MultiAddress.TryCreate((string)a!))
+                .Where(ma => ma is not null)
+                .Cast<MultiAddress>();
         }
 
         public Task RemoveAllAsync(CancellationToken cancel = default)
@@ -56,7 +68,7 @@ namespace Ipfs.Http
             var a = addrs.FirstOrDefault();
             if (a is null)
                 return null;
-            return new MultiAddress((string?)a);
+            return new MultiAddress((string)a!);
         }
     }
 }

--- a/src/CoreApi/BootstrapApi.cs
+++ b/src/CoreApi/BootstrapApi.cs
@@ -9,55 +9,54 @@ namespace Ipfs.Http
 {
     class BootstrapApi : IBootstrapApi
     {
-        IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal BootstrapApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public async Task<MultiAddress> AddAsync(MultiAddress address, CancellationToken cancel = default(CancellationToken))
+        public async Task<MultiAddress?> AddAsync(MultiAddress address, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("bootstrap/add", cancel, address.ToString());
-            var addrs = (JArray)(JObject.Parse(json)["Peers"]);
+            var addrs = (JArray?)(JObject.Parse(json)["Peers"]);
             var a = addrs.FirstOrDefault();
-            if (a == null)
+            if (a is null)
                 return null;
-            return new MultiAddress((string)a);
+            return new MultiAddress((string?)a);
         }
 
-        public async Task<IEnumerable<MultiAddress>> AddDefaultsAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<MultiAddress>> AddDefaultsAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("bootstrap/add/default", cancel);
-            var addrs = (JArray)(JObject.Parse(json)["Peers"]);
+            var addrs = (JArray?)(JObject.Parse(json)["Peers"]);
             return addrs
-                .Select(a => MultiAddress.TryCreate((string)a))
-                .Where(ma => ma != null);
+                .Select(a => MultiAddress.TryCreate((string?)a))
+                .Where(ma => ma is not null);
         }
 
-        public async Task<IEnumerable<MultiAddress>> ListAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<MultiAddress>> ListAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("bootstrap/list", cancel);
-            var addrs = (JArray)(JObject.Parse(json)["Peers"]);
+            var addrs = (JArray?)(JObject.Parse(json)["Peers"]);
             return addrs
-                .Select(a => MultiAddress.TryCreate((string)a))
-                .Where(ma => ma != null);
+                .Select(a => MultiAddress.TryCreate((string?)a))
+                .Where(ma => ma is not null);
         }
 
-        public Task RemoveAllAsync(CancellationToken cancel = default(CancellationToken))
+        public Task RemoveAllAsync(CancellationToken cancel = default)
         {
             return ipfs.DoCommandAsync("bootstrap/rm/all", cancel);
         }
 
-        public async Task<MultiAddress> RemoveAsync(MultiAddress address, CancellationToken cancel = default(CancellationToken))
+        public async Task<MultiAddress?> RemoveAsync(MultiAddress address, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("bootstrap/rm", cancel, address.ToString());
-            var addrs = (JArray)(JObject.Parse(json)["Peers"]);
+            var addrs = (JArray?)(JObject.Parse(json)["Peers"]);
             var a = addrs.FirstOrDefault();
-            if (a == null)
+            if (a is null)
                 return null;
-            return new MultiAddress((string)a);
+            return new MultiAddress((string?)a);
         }
     }
-
 }

--- a/src/CoreApi/ConfigApi.cs
+++ b/src/CoreApi/ConfigApi.cs
@@ -9,46 +9,43 @@ namespace Ipfs.Http
 {
     class ConfigApi : IConfigApi
     {
-        IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal ConfigApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public async Task<JObject> GetAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task<JObject> GetAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("config/show", cancel);
             return JObject.Parse(json);
         }
 
-        public async Task<JToken> GetAsync(string key, CancellationToken cancel = default(CancellationToken))
+        public async Task<JToken> GetAsync(string key, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("config", cancel, key);
             var r = JObject.Parse(json);
-            return r["Value"];
+            return r["Value"]!;
         }
 
-        public async Task SetAsync(string key, string value, CancellationToken cancel = default(CancellationToken))
+        public Task SetAsync(string key, string value, CancellationToken cancel = default)
         {
-            var _ = await ipfs.DoCommandAsync("config", cancel, key, "arg=" + value);
-            return;
+            return ipfs.DoCommandAsync("config", cancel, key, "arg=" + value);
         }
 
-        public async Task SetAsync(string key, JToken value, CancellationToken cancel = default(CancellationToken))
+        public Task SetAsync(string key, JToken value, CancellationToken cancel = default)
         {
-            var _ = await ipfs.DoCommandAsync("config", cancel,
+            return ipfs.DoCommandAsync("config", cancel,
                 key,
                 "arg=" + value.ToString(Formatting.None),
                 "json=true");
-            return;
         }
 
-        public async Task ReplaceAsync(JObject config)
+        public Task ReplaceAsync(JObject config)
         {
             var data = Encoding.UTF8.GetBytes(config.ToString(Formatting.None));
-            await ipfs.UploadAsync("config/replace", CancellationToken.None, data);
+            return ipfs.UploadAsync("config/replace", CancellationToken.None, data);
         }
     }
-
 }

--- a/src/CoreApi/DagApi.cs
+++ b/src/CoreApi/DagApi.cs
@@ -74,7 +74,7 @@ namespace Ipfs.Http
                 $"hash={multiHash}",
                 $"cid-base={encoding}");
             var result = JObject.Parse(json);
-            return (Cid)(string?)result["Cid"]["/"];
+            return (Cid)(string)result["Cid"]!["/"]!;
         }
 
         public async Task<JObject> GetAsync(Cid id, CancellationToken cancel = default)
@@ -89,7 +89,7 @@ namespace Ipfs.Http
             return JToken.Parse(json);
         }
 
-        public async Task<T> GetAsync<T>(Cid id, CancellationToken cancel = default)
+        public async Task<T?> GetAsync<T>(Cid id, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("dag/get", cancel, id);
             return JsonConvert.DeserializeObject<T>(json);

--- a/src/CoreApi/DagApi.cs
+++ b/src/CoreApi/DagApi.cs
@@ -11,7 +11,7 @@ namespace Ipfs.Http
 {
     class DagApi : IDagApi
     {
-        private IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal DagApi(IpfsClient ipfs)
         {
@@ -24,7 +24,7 @@ namespace Ipfs.Http
             string multiHash = MultiHash.DefaultAlgorithmName,
             string encoding = MultiBase.DefaultAlgorithmName,
             bool pin = true,
-            CancellationToken cancel = default(CancellationToken))
+            CancellationToken cancel = default)
         {
             using (var ms = new MemoryStream())
             {
@@ -48,7 +48,7 @@ namespace Ipfs.Http
             string multiHash = MultiHash.DefaultAlgorithmName,
             string encoding = MultiBase.DefaultAlgorithmName,
             bool pin = true,
-            CancellationToken cancel = default(CancellationToken))
+            CancellationToken cancel = default)
         {
             using (var ms = new MemoryStream(
                 Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data)),
@@ -64,36 +64,32 @@ namespace Ipfs.Http
             string multiHash = MultiHash.DefaultAlgorithmName,
             string encoding = MultiBase.DefaultAlgorithmName,
             bool pin = true,
-            CancellationToken cancel = default(CancellationToken))
+            CancellationToken cancel = default)
         {
             var json = await ipfs.UploadAsync("dag/put", cancel,
-                data, null,
+                data,
+                name: null,
                 $"format={contentType}",
                 $"pin={pin.ToString().ToLowerInvariant()}",
                 $"hash={multiHash}",
                 $"cid-base={encoding}");
             var result = JObject.Parse(json);
-            return (Cid)(string)result["Cid"]["/"];
+            return (Cid)(string?)result["Cid"]["/"];
         }
 
-        public async Task<JObject> GetAsync(
-            Cid id,
-            CancellationToken cancel = default(CancellationToken))
+        public async Task<JObject> GetAsync(Cid id, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("dag/get", cancel, id);
             return JObject.Parse(json);
         }
 
-
-        public async Task<JToken> GetAsync(
-            string path,
-            CancellationToken cancel = default(CancellationToken))
+        public async Task<JToken> GetAsync(string path, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("dag/get", cancel, path);
             return JToken.Parse(json);
         }
 
-        public async Task<T> GetAsync<T>(Cid id, CancellationToken cancel = default(CancellationToken))
+        public async Task<T> GetAsync<T>(Cid id, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("dag/get", cancel, id);
             return JsonConvert.DeserializeObject<T>(json);

--- a/src/CoreApi/DhtApi.cs
+++ b/src/CoreApi/DhtApi.cs
@@ -10,41 +10,41 @@ namespace Ipfs.Http
 {
     class DhtApi : IDhtApi
     {
-        private IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal DhtApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public Task<Peer> FindPeerAsync(MultiHash id, CancellationToken cancel = default(CancellationToken))
+        public Task<Peer> FindPeerAsync(MultiHash id, CancellationToken cancel = default)
         {
             return ipfs.IdAsync(id, cancel);
         }
 
-        public async Task<IEnumerable<Peer>> FindProvidersAsync(Cid id, int limit = 20, Action<Peer> providerFound = null, CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<Peer>> FindProvidersAsync(Cid id, int limit = 20, Action<Peer>? providerFound = null, CancellationToken cancel = default)
         {
             // TODO: providerFound action
             var stream = await ipfs.PostDownloadAsync("dht/findprovs", cancel, id, $"num-providers={limit}");
             return ProviderFromStream(stream, limit);
         }
 
-        public Task<byte[]> GetAsync(byte[] key, CancellationToken cancel = default(CancellationToken))
+        public Task<byte[]> GetAsync(byte[] key, CancellationToken cancel = default)
         {
             throw new NotImplementedException();
         }
 
-        public Task ProvideAsync(Cid cid, bool advertise = true, CancellationToken cancel = default(CancellationToken))
+        public Task ProvideAsync(Cid cid, bool advertise = true, CancellationToken cancel = default)
         {
             throw new NotImplementedException();
         }
 
-        public Task PutAsync(byte[] key, out byte[] value, CancellationToken cancel = default(CancellationToken))
+        public Task PutAsync(byte[] key, out byte[] value, CancellationToken cancel = default)
         {
             throw new NotImplementedException();
         }
 
-        public Task<bool> TryGetAsync(byte[] key, out byte[] value, CancellationToken cancel = default(CancellationToken))
+        public Task<bool> TryGetAsync(byte[] key, out byte[] value, CancellationToken cancel = default)
         {
             throw new NotImplementedException();
         }
@@ -59,21 +59,21 @@ namespace Ipfs.Http
                     var json = sr.ReadLine();
 
                     var r = JObject.Parse(json);
-                    var id = (string)r["ID"];
-                    if (id != String.Empty)
+                    var id = (string?)r["ID"];
+                    if (id != string.Empty)
                     {
                         ++n;
                         yield return new Peer { Id = new MultiHash(id) };
                     }
                     else
                     {
-                        var responses = (JArray)r["Responses"];
-                        if (responses != null)
+                        var responses = (JArray?)r["Responses"];
+                        if (responses is not null)
                         {
                             foreach (var response in responses)
                             {
-                                var rid = (string)response["ID"];
-                                if (rid != String.Empty)
+                                var rid = (string?)response["ID"];
+                                if (rid != string.Empty)
                                 {
                                     ++n;
                                     yield return new Peer { Id = new MultiHash(rid) };
@@ -85,5 +85,4 @@ namespace Ipfs.Http
             }
         }
     }
-
 }

--- a/src/CoreApi/DhtApi.cs
+++ b/src/CoreApi/DhtApi.cs
@@ -60,10 +60,10 @@ namespace Ipfs.Http
 
                     var r = JObject.Parse(json);
                     var id = (string?)r["ID"];
-                    if (id != string.Empty)
+                    if (!string.IsNullOrEmpty(id))
                     {
                         ++n;
-                        yield return new Peer { Id = new MultiHash(id) };
+                        yield return new Peer { Id = new MultiHash(id!) };
                     }
                     else
                     {
@@ -73,10 +73,10 @@ namespace Ipfs.Http
                             foreach (var response in responses)
                             {
                                 var rid = (string?)response["ID"];
-                                if (rid != string.Empty)
+                                if (!string.IsNullOrEmpty(rid))
                                 {
                                     ++n;
-                                    yield return new Peer { Id = new MultiHash(rid) };
+                                    yield return new Peer { Id = new MultiHash(rid!) };
                                 }
                             }
                         }

--- a/src/CoreApi/DnsApi.cs
+++ b/src/CoreApi/DnsApi.cs
@@ -7,20 +7,20 @@ namespace Ipfs.Http
 {
     class DnsApi : IDnsApi
     {
-        private IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal DnsApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public async Task<string> ResolveAsync(string name, bool recursive = false, CancellationToken cancel = default(CancellationToken))
+        public async Task<string> ResolveAsync(string name, bool recursive = false, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("dns", cancel,
                 name,
                 $"recursive={recursive.ToString().ToLowerInvariant()}");
-            var path = (string)(JObject.Parse(json)["Path"]);
-            return path;
+            var path = (string?)(JObject.Parse(json)["Path"]);
+            return path ?? string.Empty;
         }
     }
 }

--- a/src/CoreApi/GenericApi.cs
+++ b/src/CoreApi/GenericApi.cs
@@ -14,13 +14,13 @@ namespace Ipfs.Http
         private const double TicksPerNanosecond = (double)TimeSpan.TicksPerMillisecond * 0.000001;
 
         /// <inheritdoc />
-        public Task<Peer> IdAsync(MultiHash peer = null, CancellationToken cancel = default(CancellationToken))
+        public Task<Peer> IdAsync(MultiHash? peer = null, CancellationToken cancel = default)
         {
             return DoCommandAsync<Peer>("id", cancel, peer?.ToString());
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<PingResult>> PingAsync(MultiHash peer, int count = 10, CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<PingResult>> PingAsync(MultiHash peer, int count = 10, CancellationToken cancel = default)
         {
             var stream = await PostDownloadAsync("ping", cancel,
                 peer.ToString(),
@@ -29,7 +29,7 @@ namespace Ipfs.Http
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<PingResult>> PingAsync(MultiAddress address, int count = 10, CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<PingResult>> PingAsync(MultiAddress address, int count = 10, CancellationToken cancel = default)
         {
             var stream = await PostDownloadAsync("ping", cancel,
                 address.ToString(),
@@ -48,35 +48,34 @@ namespace Ipfs.Http
                     var r = JObject.Parse(json);
                     yield return new PingResult
                     {
-                        Success = (bool)r["Success"],
-                        Text = (string)r["Text"],
-                        Time = TimeSpan.FromTicks((long)((long)r["Time"] * TicksPerNanosecond))
+                        Success = (bool?)r["Success"] ?? false,
+                        Text = (string?)r["Text"],
+                        Time = TimeSpan.FromTicks((long)(((long?)r["Time"] ?? 0) * TicksPerNanosecond))
                     };
                 }
             }
         }
 
         /// <inheritdoc />
-        public async Task<string> ResolveAsync(string name, bool recursive = true, CancellationToken cancel = default(CancellationToken))
+        public async Task<string> ResolveAsync(string name, bool recursive = true, CancellationToken cancel = default)
         {
             var json = await DoCommandAsync("resolve", cancel,
                 name,
                 $"recursive={recursive.ToString().ToLowerInvariant()}");
-            var path = (string)(JObject.Parse(json)["Path"]);
-            return path;
+            var path = (string?)(JObject.Parse(json)["Path"]);
+            return path ?? string.Empty;
         }
 
         /// <inheritdoc />
         public async Task ShutdownAsync()
         {
-            await DoCommandAsync("shutdown", default(CancellationToken));
+            await DoCommandAsync("shutdown", default);
         }
 
         /// <inheritdoc />
-        public Task<Dictionary<string, string>> VersionAsync(CancellationToken cancel = default(CancellationToken))
+        public Task<Dictionary<string, string>> VersionAsync(CancellationToken cancel = default)
         {
             return DoCommandAsync<Dictionary<string, string>>("version", cancel);
         }
-
     }
 }

--- a/src/CoreApi/KeyApi.cs
+++ b/src/CoreApi/KeyApi.cs
@@ -1,25 +1,31 @@
-﻿using Ipfs.CoreApi;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Ipfs.CoreApi;
+using Newtonsoft.Json.Linq;
 
 namespace Ipfs.Http
 {
-    class KeyApi : IKeyApi
+    internal class KeyApi : IKeyApi
     {
         /// <summary>
         ///   Information about a local key.
         /// </summary>
-        public class KeyInfo : IKey
+        public sealed class KeyInfo : IKey
         {
-            /// <inheritdoc />
-            public MultiHash? Id { get; set; }
+            public KeyInfo(MultiHash id, string name)
+            {
+                Id = id;
+                Name = name;
+            }
 
             /// <inheritdoc />
-            public string? Name { get; set; }
+            public MultiHash Id { get; }
+
+            /// <inheritdoc />
+            public string Name { get; }
 
             /// <inheritdoc />
             public override string ToString()
@@ -48,11 +54,7 @@ namespace Ipfs.Http
             var json = await ipfs.DoCommandAsync("key/list", cancel, null, "l=true");
             var keys = (JArray?)(JObject.Parse(json)["Keys"]);
             return keys
-                .Select(k => new KeyInfo
-                {
-                    Id = (string?)k["Id"],
-                    Name = (string?)k["Name"]
-                });
+                .Select(k => new KeyInfo((string)k["Id"]!, (string)k["Name"]!));
         }
 
         public async Task<IKey?> RemoveAsync(string name, CancellationToken cancel = default)
@@ -61,11 +63,7 @@ namespace Ipfs.Http
             var keys = JObject.Parse(json)["Keys"] as JArray;
 
             return keys?
-                .Select(k => new KeyInfo
-                {
-                    Id = (string?)k["Id"],
-                    Name = (string?)k["Name"]
-                })
+                .Select(k => new KeyInfo((string)k["Id"]!, (string)k["Name"]!))
                 .First();
         }
 
@@ -73,11 +71,7 @@ namespace Ipfs.Http
         {
             var json = await ipfs.DoCommandAsync("key/rename", cancel, oldName, $"arg={newName}");
             var key = JObject.Parse(json);
-            return new KeyInfo
-            {
-                Id = (string?)key["Id"],
-                Name = (string?)key["Now"]
-            };
+            return new KeyInfo((string)key["Id"]!, (string)key["Now"]!);
         }
 
         public Task<string> ExportAsync(string name, char[] password, CancellationToken cancel = default)

--- a/src/CoreApi/KeyApi.cs
+++ b/src/CoreApi/KeyApi.cs
@@ -16,26 +16,26 @@ namespace Ipfs.Http
         public class KeyInfo : IKey
         {
             /// <inheritdoc />
-            public MultiHash Id { get; set; }
+            public MultiHash? Id { get; set; }
 
             /// <inheritdoc />
-            public string Name { get; set; }
+            public string? Name { get; set; }
 
             /// <inheritdoc />
             public override string ToString()
             {
-                return Name;
+                return Name ?? string.Empty;
             }
-
         }
-        IpfsClient ipfs;
+
+        private readonly IpfsClient ipfs;
 
         internal KeyApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public async Task<IKey> CreateAsync(string name, string keyType, int size, CancellationToken cancel = default(CancellationToken))
+        public async Task<IKey> CreateAsync(string name, string keyType, int size, CancellationToken cancel = default)
         {
             return await ipfs.DoCommandAsync<KeyInfo>("key/gen", cancel,
                 name,
@@ -43,19 +43,19 @@ namespace Ipfs.Http
                 $"size={size}");
         }
 
-        public async Task<IEnumerable<IKey>> ListAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<IKey>> ListAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("key/list", cancel, null, "l=true");
-            var keys = (JArray)(JObject.Parse(json)["Keys"]);
+            var keys = (JArray?)(JObject.Parse(json)["Keys"]);
             return keys
                 .Select(k => new KeyInfo
                 {
-                    Id = (string)k["Id"],
-                    Name = (string)k["Name"]
+                    Id = (string?)k["Id"],
+                    Name = (string?)k["Name"]
                 });
         }
 
-        public async Task<IKey> RemoveAsync(string name, CancellationToken cancel = default(CancellationToken))
+        public async Task<IKey?> RemoveAsync(string name, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("key/rm", cancel, name);
             var keys = JObject.Parse(json)["Keys"] as JArray;
@@ -63,29 +63,29 @@ namespace Ipfs.Http
             return keys?
                 .Select(k => new KeyInfo
                 {
-                    Id = (string)k["Id"],
-                    Name = (string)k["Name"]
+                    Id = (string?)k["Id"],
+                    Name = (string?)k["Name"]
                 })
                 .First();
         }
 
-        public async Task<IKey> RenameAsync(string oldName, string newName, CancellationToken cancel = default(CancellationToken))
+        public async Task<IKey> RenameAsync(string oldName, string newName, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("key/rename", cancel, oldName, $"arg={newName}");
             var key = JObject.Parse(json);
             return new KeyInfo
             {
-                Id = (string)key["Id"],
-                Name = (string)key["Now"]
+                Id = (string?)key["Id"],
+                Name = (string?)key["Now"]
             };
         }
 
-        public Task<string> ExportAsync(string name, char[] password, CancellationToken cancel = default(CancellationToken))
+        public Task<string> ExportAsync(string name, char[] password, CancellationToken cancel = default)
         {
             throw new NotImplementedException();
         }
 
-        public Task<IKey> ImportAsync(string name, string pem, char[] password = null, CancellationToken cancel = default(CancellationToken))
+        public Task<IKey> ImportAsync(string name, string pem, char[]? password = null, CancellationToken cancel = default)
         {
             throw new NotImplementedException();
         }

--- a/src/CoreApi/NameApi.cs
+++ b/src/CoreApi/NameApi.cs
@@ -8,14 +8,14 @@ namespace Ipfs.Http
 {
     class NameApi : INameApi
     {
-        private IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal NameApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public async Task<NamedContent> PublishAsync(string path, bool resolve = true, string key = "self", TimeSpan? lifetime = null, CancellationToken cancel = default(CancellationToken))
+        public async Task<NamedContent> PublishAsync(string path, bool resolve = true, string key = "self", TimeSpan? lifetime = null, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("name/publish", cancel,
                 path,
@@ -26,12 +26,12 @@ namespace Ipfs.Http
             var info = JObject.Parse(json);
             return new NamedContent
             {
-                NamePath = (string)info["Name"],
-                ContentPath = (string)info["Value"]
+                NamePath = (string?)info["Name"],
+                ContentPath = (string?)info["Value"]
             };
         }
 
-        public Task<NamedContent> PublishAsync(Cid id, string key = "self", TimeSpan? lifetime = null, CancellationToken cancel = default(CancellationToken))
+        public Task<NamedContent> PublishAsync(Cid id, string key = "self", TimeSpan? lifetime = null, CancellationToken cancel = default)
         {
             return PublishAsync("/ipfs/" + id.Encode(), false, key, lifetime, cancel);
         }
@@ -42,8 +42,8 @@ namespace Ipfs.Http
                 name,
                 $"recursive={recursive.ToString().ToLowerInvariant()}",
                 $"nocache={nocache.ToString().ToLowerInvariant()}");
-            var path = (string)(JObject.Parse(json)["Path"]);
-            return path;
+            var path = (string?)(JObject.Parse(json)["Path"]);
+            return path ?? string.Empty;
         }
     }
 }

--- a/src/CoreApi/ObjectApi.cs
+++ b/src/CoreApi/ObjectApi.cs
@@ -27,7 +27,7 @@ namespace Ipfs.Http
         {
             var json = await ipfs.DoCommandAsync("object/new", cancel, template);
             var hash = (string?)(JObject.Parse(json)["Hash"]);
-            return await GetAsync(hash);
+            return await GetAsync(hash!);
         }
 
         public async Task<DagNode> GetAsync(Cid id, CancellationToken cancel = default)
@@ -70,7 +70,7 @@ namespace Ipfs.Http
             var links = ((JArray?)result["Links"])
                 .Select(link => new DagLink(
                     (string?)link["Name"],
-                    (string?)link["Hash"],
+                    (string)link["Hash"]!,
                     (long?)link["Size"] ?? 0));
             return new DagNode(data, links);
         }

--- a/src/CoreApi/ObjectApi.cs
+++ b/src/CoreApi/ObjectApi.cs
@@ -11,48 +11,48 @@ namespace Ipfs.Http
 {
     class ObjectApi : IObjectApi
     {
-        private IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal ObjectApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public Task<DagNode> NewDirectoryAsync(CancellationToken cancel = default(CancellationToken))
+        public Task<DagNode> NewDirectoryAsync(CancellationToken cancel = default)
         {
             return NewAsync("unixfs-dir", cancel);
         }
 
-        public async Task<DagNode> NewAsync(string template = null, CancellationToken cancel = default(CancellationToken))
+        public async Task<DagNode> NewAsync(string? template = null, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("object/new", cancel, template);
-            var hash = (string)(JObject.Parse(json)["Hash"]);
+            var hash = (string?)(JObject.Parse(json)["Hash"]);
             return await GetAsync(hash);
         }
 
-        public async Task<DagNode> GetAsync(Cid id, CancellationToken cancel = default(CancellationToken))
+        public async Task<DagNode> GetAsync(Cid id, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("object/get", cancel, id);
             return GetDagFromJson(json);
         }
 
-        public Task<DagNode> PutAsync(byte[] data, IEnumerable<IMerkleLink> links = null, CancellationToken cancel = default(CancellationToken))
+        public Task<DagNode> PutAsync(byte[] data, IEnumerable<IMerkleLink>? links = null, CancellationToken cancel = default)
         {
             return PutAsync(new DagNode(data, links), cancel);
         }
 
-        public async Task<DagNode> PutAsync(DagNode node, CancellationToken cancel = default(CancellationToken))
+        public async Task<DagNode> PutAsync(DagNode node, CancellationToken cancel = default)
         {
             var json = await ipfs.UploadAsync("object/put", cancel, node.ToArray(), "inputenc=protobuf");
             return node;
         }
 
-        public Task<Stream> DataAsync(Cid id, CancellationToken cancel = default(CancellationToken))
+        public Task<Stream> DataAsync(Cid id, CancellationToken cancel = default)
         {
             return ipfs.PostDownloadAsync("object/data", cancel, id);
         }
 
-        public async Task<IEnumerable<IMerkleLink>> LinksAsync(Cid id, CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<IMerkleLink>> LinksAsync(Cid id, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("object/links", cancel, id);
             return GetDagFromJson(json).Links;
@@ -63,30 +63,30 @@ namespace Ipfs.Http
         DagNode GetDagFromJson(string json)
         {
             var result = JObject.Parse(json);
-            byte[] data = null;
-            var stringData = (string)result["Data"];
-            if (stringData != null)
+            byte[]? data = null;
+            var stringData = (string?)result["Data"];
+            if (stringData is not null)
                 data = Encoding.UTF8.GetBytes(stringData);
-            var links = ((JArray)result["Links"])
+            var links = ((JArray?)result["Links"])
                 .Select(link => new DagLink(
-                    (string)link["Name"],
-                    (string)link["Hash"],
-                    (long)link["Size"]));
+                    (string?)link["Name"],
+                    (string?)link["Hash"],
+                    (long?)link["Size"] ?? 0));
             return new DagNode(data, links);
         }
 
-        public async Task<ObjectStat> StatAsync(Cid id, CancellationToken cancel = default(CancellationToken))
+        public async Task<ObjectStat> StatAsync(Cid id, CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("object/stat", cancel, id);
             var r = JObject.Parse(json);
 
             return new ObjectStat
             {
-                LinkCount = (int)r["NumLinks"],
-                LinkSize = (long)r["LinksSize"],
-                BlockSize = (long)r["BlockSize"],
-                DataSize = (long)r["DataSize"],
-                CumulativeSize = (long)r["CumulativeSize"]
+                LinkCount = (int?)r["NumLinks"] ?? 0,
+                LinkSize = (long?)r["LinksSize"] ?? 0,
+                BlockSize = (long?)r["BlockSize"] ?? 0,
+                DataSize = (long?)r["DataSize"] ?? 0,
+                CumulativeSize = (long?)r["CumulativeSize"] ?? 0,
             };
         }
     }

--- a/src/CoreApi/PinApi.cs
+++ b/src/CoreApi/PinApi.cs
@@ -9,38 +9,41 @@ namespace Ipfs.Http
 {
     class PinApi : IPinApi
     {
-        private IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal PinApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public async Task<IEnumerable<Cid>> AddAsync(string path, bool recursive = true, CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<Cid>> AddAsync(string path, bool recursive = true, CancellationToken cancel = default)
         {
             var opts = "recursive=" + recursive.ToString().ToLowerInvariant();
             var json = await ipfs.DoCommandAsync("pin/add", cancel, path, opts);
-            return ((JArray)JObject.Parse(json)["Pins"])
-                .Select(p => (Cid)(string)p);
+            return ((JArray?)JObject.Parse(json)["Pins"])
+                .Select(p => (Cid)(string?)p);
         }
 
-        public async Task<IEnumerable<Cid>> ListAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<Cid>> ListAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("pin/ls", cancel);
-            var keys = (JObject)(JObject.Parse(json)["Keys"]);
+            var keys = (JObject?)(JObject.Parse(json)["Keys"]);
+            if (keys is null)
+            {
+                return Enumerable.Empty<Cid>();
+            }
+
             return keys
                 .Properties()
                 .Select(p => (Cid)p.Name);
         }
 
-        public async Task<IEnumerable<Cid>> RemoveAsync(Cid id, bool recursive = true, CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<Cid>> RemoveAsync(Cid id, bool recursive = true, CancellationToken cancel = default)
         {
             var opts = "recursive=" + recursive.ToString().ToLowerInvariant();
             var json = await ipfs.DoCommandAsync("pin/rm", cancel, id, opts);
-            return ((JArray)JObject.Parse(json)["Pins"])
-                .Select(p => (Cid)(string)p);
+            return ((JArray?)JObject.Parse(json)["Pins"])
+                .Select(p => (Cid)(string?)p);
         }
-
     }
-
 }

--- a/src/CoreApi/PinApi.cs
+++ b/src/CoreApi/PinApi.cs
@@ -21,7 +21,7 @@ namespace Ipfs.Http
             var opts = "recursive=" + recursive.ToString().ToLowerInvariant();
             var json = await ipfs.DoCommandAsync("pin/add", cancel, path, opts);
             return ((JArray?)JObject.Parse(json)["Pins"])
-                .Select(p => (Cid)(string?)p);
+                .Select(p => (Cid)(string)p!);
         }
 
         public async Task<IEnumerable<Cid>> ListAsync(CancellationToken cancel = default)
@@ -43,7 +43,7 @@ namespace Ipfs.Http
             var opts = "recursive=" + recursive.ToString().ToLowerInvariant();
             var json = await ipfs.DoCommandAsync("pin/rm", cancel, id, opts);
             return ((JArray?)JObject.Parse(json)["Pins"])
-                .Select(p => (Cid)(string?)p);
+                .Select(p => (Cid)(string)p!);
         }
     }
 }

--- a/src/CoreApi/PubSubApi.cs
+++ b/src/CoreApi/PubSubApi.cs
@@ -114,7 +114,5 @@ namespace Ipfs.Http
                 sr.Dispose();
             }
         }
-
     }
-
 }

--- a/src/CoreApi/PubSubApi.cs
+++ b/src/CoreApi/PubSubApi.cs
@@ -1,13 +1,13 @@
-﻿using Ipfs.CoreApi;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Ipfs.CoreApi;
 using Multiformats.Base;
+using Newtonsoft.Json.Linq;
 
 namespace Ipfs.Http
 {
@@ -26,7 +26,7 @@ namespace Ipfs.Http
             var result = JObject.Parse(json);
             var strings = result["Strings"] as JArray;
             if (strings is null) return Enumerable.Empty<string>();
-            return strings.Select(s => (string)s);
+            return strings.Select(s => (string)s!);
         }
 
         public async Task<IEnumerable<Peer>> PeersAsync(string? topic = null, CancellationToken cancel = default)
@@ -36,9 +36,11 @@ namespace Ipfs.Http
             var strings = result["Strings"] as JArray;
 
             if (strings is null)
+            {
                 return Enumerable.Empty<Peer>();
+            }
 
-            return strings.Select(s => new Peer { Id = (string?)s });
+            return strings.Select(s => new Peer { Id = (string)s! });
         }
 
         public Task PublishAsync(string topic, byte[] message, CancellationToken cancel = default)

--- a/src/CoreApi/StatsApi.cs
+++ b/src/CoreApi/StatsApi.cs
@@ -9,41 +9,39 @@ namespace Ipfs.Http
 
     class StatApi : IStatsApi
     {
-        private IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal StatApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public Task<BandwidthData> BandwidthAsync(CancellationToken cancel = default(CancellationToken))
+        public Task<BandwidthData> BandwidthAsync(CancellationToken cancel = default)
         {
             return ipfs.DoCommandAsync<BandwidthData>("stats/bw", cancel);
         }
 
-        public async Task<BitswapData> BitswapAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task<BitswapData> BitswapAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("stats/bitswap", cancel);
             var stat = JObject.Parse(json);
             return new BitswapData
             {
-                BlocksReceived = (ulong)stat["BlocksReceived"],
-                DataReceived = (ulong)stat["DataReceived"],
-                BlocksSent = (ulong)stat["BlocksSent"],
-                DataSent = (ulong)stat["DataSent"],
-                DupBlksReceived = (ulong)stat["DupBlksReceived"],
-                DupDataReceived = (ulong)stat["DupDataReceived"],
-                ProvideBufLen = (int)stat["ProvideBufLen"],
-                Peers = ((JArray)stat["Peers"]).Select(s => new MultiHash((string)s)),
-                Wantlist = ((JArray)stat["Wantlist"]).Select(o => Cid.Decode(o["/"].ToString()))
+                BlocksReceived = (ulong?)stat["BlocksReceived"] ?? 0,
+                DataReceived = (ulong?)stat["DataReceived"] ?? 0,
+                BlocksSent = (ulong?)stat["BlocksSent"] ?? 0,
+                DataSent = (ulong?)stat["DataSent"] ?? 0,
+                DupBlksReceived = (ulong?)stat["DupBlksReceived"] ?? 0,
+                DupDataReceived = (ulong?)stat["DupDataReceived"] ?? 0,
+                ProvideBufLen = (int?)stat["ProvideBufLen"] ?? 0,
+                Peers = ((JArray?)stat["Peers"]).Select(s => new MultiHash((string?)s)),
+                Wantlist = ((JArray?)stat["Wantlist"]).Select(o => Cid.Decode(o["/"]?.ToString() ?? string.Empty))
             };
         }
 
-        public Task<RepositoryData> RepositoryAsync(CancellationToken cancel = default(CancellationToken))
+        public Task<RepositoryData> RepositoryAsync(CancellationToken cancel = default)
         {
             return ipfs.DoCommandAsync<RepositoryData>("stats/repo", cancel);
         }
-
-
     }
 }

--- a/src/CoreApi/StatsApi.cs
+++ b/src/CoreApi/StatsApi.cs
@@ -34,7 +34,7 @@ namespace Ipfs.Http
                 DupBlksReceived = (ulong?)stat["DupBlksReceived"] ?? 0,
                 DupDataReceived = (ulong?)stat["DupDataReceived"] ?? 0,
                 ProvideBufLen = (int?)stat["ProvideBufLen"] ?? 0,
-                Peers = ((JArray?)stat["Peers"]).Select(s => new MultiHash((string?)s)),
+                Peers = ((JArray?)stat["Peers"]).Select(s => new MultiHash((string)s!)).ToList(),
                 Wantlist = ((JArray?)stat["Wantlist"]).Select(o => Cid.Decode(o["/"]?.ToString() ?? string.Empty))
             };
         }

--- a/src/CoreApi/SwarmApi.cs
+++ b/src/CoreApi/SwarmApi.cs
@@ -38,8 +38,9 @@ namespace Ipfs.Http
                 {
                     Id = p.Name,
                     Addresses = ((JArray)p.Value)
-                        .Select(a => MultiAddress.TryCreate((string?)a))
+                        .Select(a => MultiAddress.TryCreate((string)a!))
                         .Where(ma => ma is not null)
+                        .Cast<MultiAddress>()
                 });
         }
 
@@ -55,8 +56,8 @@ namespace Ipfs.Http
                 return strings
                    .Select(s =>
                    {
-                       var parts = ((string?)s)?.Split(' ');
-                       var address = new MultiAddress(parts?[0]);
+                       var parts = ((string)s)!.Split(' ');
+                       var address = new MultiAddress(parts[0]);
                        return new Peer
                        {
                            Id = address.PeerId,
@@ -72,9 +73,9 @@ namespace Ipfs.Http
             {
                 return peers.Select(p => new Peer
                 {
-                    Id = (string?)p["Peer"],
+                    Id = (string)p["Peer"]!,
                     ConnectedAddress = new MultiAddress((string?)p["Addr"] + "/ipfs/" + (string?)p["Peer"]),
-                    Latency = Duration.Parse((string?)p["Latency"])
+                    Latency = Duration.Parse((string?)p["Latency"] ?? "0")
                 });
             }
 
@@ -100,7 +101,7 @@ namespace Ipfs.Http
             var a = addrs.FirstOrDefault();
             if (a is null)
                 return null;
-            return new MultiAddress((string?)a);
+            return new MultiAddress((string)a!);
         }
 
         public async Task<IEnumerable<MultiAddress>> ListAddressFiltersAsync(bool persist = false, CancellationToken cancel = default)
@@ -117,10 +118,11 @@ namespace Ipfs.Http
             }
 
             if (addrs is null)
-                return new MultiAddress[0];
+                return Enumerable.Empty<MultiAddress>();
             return addrs
-                .Select(a => MultiAddress.TryCreate((string?)a))
-                .Where(ma => ma is not null);
+                .Select(a => MultiAddress.TryCreate((string)a!))
+                .Where(ma => ma is not null)
+                .Cast<MultiAddress>();
         }
 
         public async Task<MultiAddress?> RemoveAddressFilterAsync(MultiAddress address, bool persist = false, CancellationToken cancel = default)
@@ -131,7 +133,7 @@ namespace Ipfs.Http
             var a = addrs.FirstOrDefault();
             if (a is null)
                 return null;
-            return new MultiAddress((string?)a);
+            return new MultiAddress((string)a!);
         }
     }
 }

--- a/src/CoreApi/SwarmApi.cs
+++ b/src/CoreApi/SwarmApi.cs
@@ -10,41 +10,53 @@ namespace Ipfs.Http
 {
     class SwarmApi : ISwarmApi
     {
-        private IpfsClient ipfs;
+        private readonly IpfsClient ipfs;
 
         internal SwarmApi(IpfsClient ipfs)
         {
             this.ipfs = ipfs;
         }
 
-        public async Task<IEnumerable<Peer>> AddressesAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<Peer>> AddressesAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("swarm/addrs", cancel);
-            return ((JObject)JObject.Parse(json)["Addrs"])
+            var obj = (JObject?)JObject.Parse(json);
+            if (obj is null)
+            {
+                return Enumerable.Empty<Peer>();
+            }
+
+            var addrs = (JObject?)obj["Addrs"];
+            if (addrs is null)
+            {
+                return Enumerable.Empty<Peer>();
+            }
+
+            return addrs
                 .Properties()
                 .Select(p => new Peer
                 {
                     Id = p.Name,
                     Addresses = ((JArray)p.Value)
-                        .Select(a => MultiAddress.TryCreate((string)a))
-                        .Where(ma => ma != null)
+                        .Select(a => MultiAddress.TryCreate((string?)a))
+                        .Where(ma => ma is not null)
                 });
         }
 
-        public async Task<IEnumerable<Peer>> PeersAsync(CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<Peer>> PeersAsync(CancellationToken cancel = default)
         {
             var json = await ipfs.DoCommandAsync("swarm/peers", cancel, null, "verbose=true");
             var result = JObject.Parse(json);
 
             // Older servers return an array of strings
-            var strings = (JArray)result["Strings"];
-            if (strings != null)
+            var strings = (JArray?)result["Strings"];
+            if (strings is not null)
             {
                 return strings
                    .Select(s =>
                    {
-                       var parts = ((string)s).Split(' ');
-                       var address = new MultiAddress(parts[0]);
+                       var parts = ((string?)s)?.Split(' ');
+                       var address = new MultiAddress(parts?[0]);
                        return new Peer
                        {
                            Id = address.PeerId,
@@ -55,14 +67,14 @@ namespace Ipfs.Http
             }
 
             // Current servers return JSON
-            var peers = (JArray)result["Peers"];
-            if (peers != null)
+            var peers = (JArray?)result["Peers"];
+            if (peers is not null)
             {
                 return peers.Select(p => new Peer
                 {
-                    Id = (string)p["Peer"],
-                    ConnectedAddress = new MultiAddress((string)p["Addr"] + "/ipfs/" + (string)p["Peer"]),
-                    Latency = Duration.Parse((string)p["Latency"])
+                    Id = (string?)p["Peer"],
+                    ConnectedAddress = new MultiAddress((string?)p["Addr"] + "/ipfs/" + (string?)p["Peer"]),
+                    Latency = Duration.Parse((string?)p["Latency"])
                 });
             }
 
@@ -70,30 +82,30 @@ namespace Ipfs.Http
             throw new FormatException("Unknown response from 'swarm/peers");
         }
 
-        public async Task ConnectAsync(MultiAddress address, CancellationToken cancel = default(CancellationToken))
+        public async Task ConnectAsync(MultiAddress address, CancellationToken cancel = default)
         {
             await ipfs.DoCommandAsync("swarm/connect", cancel, address.ToString());
         }
 
-        public async Task DisconnectAsync(MultiAddress address, CancellationToken cancel = default(CancellationToken))
+        public async Task DisconnectAsync(MultiAddress address, CancellationToken cancel = default)
         {
             await ipfs.DoCommandAsync("swarm/disconnect", cancel, address.ToString());
         }
 
-        public async Task<MultiAddress> AddAddressFilterAsync(MultiAddress address, bool persist = false, CancellationToken cancel = default(CancellationToken))
+        public async Task<MultiAddress?> AddAddressFilterAsync(MultiAddress address, bool persist = false, CancellationToken cancel = default)
         {
             // go-ipfs always does persist, https://github.com/ipfs/go-ipfs/issues/4605
             var json = await ipfs.DoCommandAsync("swarm/filters/add", cancel, address.ToString());
-            var addrs = (JArray)(JObject.Parse(json)["Strings"]);
+            var addrs = (JArray?)(JObject.Parse(json)["Strings"]);
             var a = addrs.FirstOrDefault();
-            if (a == null)
+            if (a is null)
                 return null;
-            return new MultiAddress((string)a);
+            return new MultiAddress((string?)a);
         }
 
-        public async Task<IEnumerable<MultiAddress>> ListAddressFiltersAsync(bool persist = false, CancellationToken cancel = default(CancellationToken))
+        public async Task<IEnumerable<MultiAddress>> ListAddressFiltersAsync(bool persist = false, CancellationToken cancel = default)
         {
-            JArray addrs;
+            JArray? addrs;
             if (persist)
             {
                 addrs = await ipfs.Config.GetAsync("Swarm.AddrFilters", cancel) as JArray;
@@ -104,23 +116,22 @@ namespace Ipfs.Http
                 addrs = (JObject.Parse(json)["Strings"]) as JArray;
             }
 
-            if (addrs == null)
+            if (addrs is null)
                 return new MultiAddress[0];
             return addrs
-                .Select(a => MultiAddress.TryCreate((string)a))
-                .Where(ma => ma != null);
+                .Select(a => MultiAddress.TryCreate((string?)a))
+                .Where(ma => ma is not null);
         }
 
-        public async Task<MultiAddress> RemoveAddressFilterAsync(MultiAddress address, bool persist = false, CancellationToken cancel = default(CancellationToken))
+        public async Task<MultiAddress?> RemoveAddressFilterAsync(MultiAddress address, bool persist = false, CancellationToken cancel = default)
         {
             // go-ipfs always does persist, https://github.com/ipfs/go-ipfs/issues/4605
             var json = await ipfs.DoCommandAsync("swarm/filters/rm", cancel, address.ToString());
-            var addrs = (JArray)(JObject.Parse(json)["Strings"]);
+            var addrs = (JArray?)(JObject.Parse(json)["Strings"]);
             var a = addrs.FirstOrDefault();
-            if (a == null)
+            if (a is null)
                 return null;
-            return new MultiAddress((string)a);
+            return new MultiAddress((string?)a);
         }
     }
-
 }

--- a/src/FileSystemLink.cs
+++ b/src/FileSystemLink.cs
@@ -6,10 +6,10 @@
     public class FileSystemLink : IFileSystemLink
     {
         /// <inheritdoc />
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <inheritdoc />
-        public Cid Id { get; set; }
+        public Cid? Id { get; set; }
 
         /// <inheritdoc />
         public long Size { get; set; }

--- a/src/FileSystemLink.cs
+++ b/src/FileSystemLink.cs
@@ -5,11 +5,20 @@
     /// </summary>
     public class FileSystemLink : IFileSystemLink
     {
+        /// <summary>
+        /// Creates a new instance of <see cref="FileSystemLink"/>.
+        /// </summary>
+        /// <param name="id"></param>
+        public FileSystemLink(Cid id)
+        {
+            Id = id;
+        }
+
         /// <inheritdoc />
         public string? Name { get; set; }
 
         /// <inheritdoc />
-        public Cid? Id { get; set; }
+        public Cid Id { get; set; }
 
         /// <inheritdoc />
         public long Size { get; set; }

--- a/src/FileSystemNode.cs
+++ b/src/FileSystemNode.cs
@@ -8,19 +8,19 @@ namespace Ipfs.Http
     [DataContract]
     public class FileSystemNode : IFileSystemNode
     {
-        IpfsClient ipfsClient;
-        IEnumerable<IFileSystemLink> links;
+        IpfsClient? ipfsClient;
+        IEnumerable<IFileSystemLink>? links;
         long? size;
         bool? isDirectory;
 
         /// <inheritdoc />
-        public byte[] DataBytes
+        public byte[]? DataBytes
         {
             get
             {
                 using (var stream = DataStream)
                 {
-                    if (DataStream == null)
+                    if (stream is null)
                         return null;
 
                     using (var data = new MemoryStream())
@@ -33,7 +33,7 @@ namespace Ipfs.Http
         }
 
         /// <inheritdoc />
-        public Stream DataStream
+        public Stream? DataStream
         {
             get
             {
@@ -43,7 +43,7 @@ namespace Ipfs.Http
 
         /// <inheritdoc />
         [DataMember]
-        public Cid Id { get; set; }
+        public Cid? Id { get; set; }
 
         /// <inheritdoc />
         [DataMember]
@@ -51,8 +51,8 @@ namespace Ipfs.Http
         {
             get
             {
-                if (links == null) GetInfo();
-                return links;
+                if (links is null) GetInfo();
+                return links!;
             }
             set
             {
@@ -73,7 +73,7 @@ namespace Ipfs.Http
             get
             {
                 if (!size.HasValue) GetInfo();
-                return size.Value;
+                return size!.Value;
             }
             set
             {
@@ -94,7 +94,7 @@ namespace Ipfs.Http
             get
             {
                 if (!isDirectory.HasValue) GetInfo();
-                return isDirectory.Value;
+                return isDirectory!.Value;
             }
             set
             {
@@ -106,7 +106,7 @@ namespace Ipfs.Http
         ///   The file name of the IPFS node.
         /// </summary>
         [DataMember]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <inheritdoc />
         public IFileSystemLink ToLink(string name = "")
@@ -130,11 +130,14 @@ namespace Ipfs.Http
         {
             get
             {
-                if (ipfsClient == null)
+                if (ipfsClient is null)
                 {
                     lock (this)
                     {
-                        ipfsClient = new IpfsClient();
+                        if (ipfsClient is null)
+                        {
+                            ipfsClient = new IpfsClient();
+                        }
                     }
                 }
                 return ipfsClient;

--- a/src/IpfsClient.cs
+++ b/src/IpfsClient.cs
@@ -26,10 +26,10 @@ namespace Ipfs.Http
     /// </remarks>
     public partial class IpfsClient : ICoreApi
     {
-        const string unknownFilename = "unknown";
+        private const string unknownFilename = "unknown";
 
-        static readonly object safe = new object();
-        static HttpClient? api = null;
+        private static readonly object safe = new object();
+        private static HttpClient? api;
 
         /// <summary>
         ///   The default URL to the IPFS HTTP API server.
@@ -42,7 +42,7 @@ namespace Ipfs.Http
         /// </remarks>
         public static Uri DefaultApiUri = new Uri(
             Environment.GetEnvironmentVariable("IpfsHttpApi")
-            ?? "http://localhost:5001");
+            ?? "http://localhost:1206");
 
         /// <summary>
         ///   Creates a new instance of the <see cref="IpfsClient"/> class and sets the
@@ -493,6 +493,7 @@ namespace Ipfs.Http
                 return json;
             }
         }
+
         /// <summary>
         ///   Perform an <see href="https://ipfs.io/docs/api/">IPFS API command</see> that
         ///   requires uploading of a "file".

--- a/src/IpfsClient.cs
+++ b/src/IpfsClient.cs
@@ -206,21 +206,21 @@ namespace Ipfs.Http
         }
 
         /// <summary>
-        ///   Get the IPFS API.
+        ///   Get the IPFS API singleton.
         /// </summary>
         /// <returns>
         ///   A <see cref="HttpClient"/>.
         /// </returns>
         /// <remarks>
-        ///   Only one client is needed.  Its thread safe.
+        ///   Only one client is needed.  It is thread safe.
         /// </remarks>
         HttpClient Api()
         {
-            if (api == null)
+            if (api is null)
             {
                 lock (safe)
                 {
-                    if (api == null)
+                    if (api is null)
                     {
                         if (HttpMessageHandler is HttpClientHandler handler && handler.SupportsAutomaticDecompression)
                         {

--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -8,7 +8,7 @@
     <DebugType>full</DebugType>
 
     <!-- https://semver.org/spec/v2.0.0.html -->
-    <Version>0.0.6</Version>
+    <Version>0.0.7</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
 
     <!-- Nuget specs -->
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.0.4" />
+    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.0.5" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Multiformats.Base" Version="2.0.2" />

--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Ipfs.Http</RootNamespace>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <DebugType>full</DebugType>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- https://semver.org/spec/v2.0.0.html -->
     <Version>0.0.6</Version>

--- a/src/MerkleNode.cs
+++ b/src/MerkleNode.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Org.BouncyCastle.Bcpg.OpenPgp;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
@@ -62,7 +63,7 @@ namespace Ipfs.Http
         public MerkleNode(IMerkleLink link)
         {
             Id = link.Id;
-            Name = link.Name;
+            Name = link.Name ?? string.Empty;
             blockSize = link.Size;
             hasBlockStats = true;
         }
@@ -131,11 +132,7 @@ namespace Ipfs.Http
         {
             get
             {
-                if (links is null)
-                {
-                    links = IpfsClient.Object.LinksAsync(Id).Result;
-                }
-
+                links ??= IpfsClient.Object.LinksAsync(Id).GetAwaiter().GetResult();
                 return links;
             }
         }

--- a/src/MerkleNode.cs
+++ b/src/MerkleNode.cs
@@ -16,9 +16,9 @@ namespace Ipfs.Http
     {
         bool hasBlockStats;
         long blockSize;
-        string name;
-        IEnumerable<IMerkleLink> links;
-        IpfsClient ipfsClient;
+        string name = string.Empty;
+        IEnumerable<IMerkleLink>? links;
+        IpfsClient? ipfsClient;
 
         /// <summary>
         ///   Creates a new instance of the <see cref="MerkleNode"/> with the specified
@@ -28,13 +28,10 @@ namespace Ipfs.Http
         ///   The <see cref="Cid"/> of the node.
         /// </param>
         /// <param name="name">A name for the node.</param>
-        public MerkleNode(Cid id, string name = null)
+        public MerkleNode(Cid id, string? name = null)
         {
-            if (id == null)
-                throw new ArgumentNullException("id");
-
             Id = id;
-            Name = name;
+            Name = name ?? string.Empty;
         }
 
         /// <summary>
@@ -45,7 +42,7 @@ namespace Ipfs.Http
         ///   The string representation of a <see cref="Cid"/> of the node or "/ipfs/cid".
         /// </param>
         /// <param name="name">A name for the node.</param>
-        public MerkleNode(string path, string name = null)
+        public MerkleNode(string path, string? name = null)
         {
             if (string.IsNullOrWhiteSpace(path))
                 throw new ArgumentNullException("path");
@@ -54,7 +51,7 @@ namespace Ipfs.Http
                 path = path.Substring(6);
 
             Id = Cid.Decode(path);
-            Name = name;
+            Name = name ?? string.Empty;
         }
 
         /// <summary>
@@ -74,7 +71,7 @@ namespace Ipfs.Http
         {
             get
             {
-                if (ipfsClient == null)
+                if (ipfsClient is null)
                 {
                     lock (this)
                     {
@@ -134,7 +131,7 @@ namespace Ipfs.Http
         {
             get
             {
-                if (links == null)
+                if (links is null)
                 {
                     links = IpfsClient.Object.LinksAsync(Id).Result;
                 }
@@ -163,7 +160,7 @@ namespace Ipfs.Http
         }
 
         /// <inheritdoc />
-        public IMerkleLink ToLink(string name = null)
+        public IMerkleLink ToLink(string? name = null)
         {
             return new DagLink(name ?? Name, Id, BlockSize);
         }
@@ -192,26 +189,26 @@ namespace Ipfs.Http
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var that = obj as MerkleNode;
-            return that != null && this.Id == that.Id;
+            return that is not null && this.Id == that.Id;
         }
 
         /// <inheritdoc />
-        public bool Equals(MerkleNode that)
+        public bool Equals(MerkleNode? that)
         {
-            return that != null && this.Id == that.Id;
+            return that is not null && this.Id == that.Id;
         }
 
         /// <summary>
         ///  TODO
         /// </summary>
-        public static bool operator ==(MerkleNode a, MerkleNode b)
+        public static bool operator ==(MerkleNode? a, MerkleNode? b)
         {
             if (object.ReferenceEquals(a, b)) return true;
-            if (object.ReferenceEquals(a, null)) return false;
-            if (object.ReferenceEquals(b, null)) return false;
+            if (a is null) return false;
+            if (b is null) return false;
 
             return a.Equals(b);
         }
@@ -219,13 +216,9 @@ namespace Ipfs.Http
         /// <summary>
         ///  TODO
         /// </summary>
-        public static bool operator !=(MerkleNode a, MerkleNode b)
+        public static bool operator !=(MerkleNode? a, MerkleNode? b)
         {
-            if (object.ReferenceEquals(a, b)) return false;
-            if (object.ReferenceEquals(a, null)) return true;
-            if (object.ReferenceEquals(b, null)) return true;
-
-            return !a.Equals(b);
+            return !(a == b);
         }
 
         /// <inheritdoc />

--- a/src/PublishedMessage.cs
+++ b/src/PublishedMessage.cs
@@ -29,7 +29,7 @@ namespace Ipfs.Http
         {
             var o = JObject.Parse(json);
 
-            this.Sender = (string?)o["from"];
+            this.Sender = (string)o["from"]!;
             this.SequenceNumber = Multibase.Decode((string?)o["seqno"], out MultibaseEncoding _);
             this.DataBytes = Multibase.Decode((string?)o["data"], out MultibaseEncoding _);
 

--- a/src/PublishedMessage.cs
+++ b/src/PublishedMessage.cs
@@ -29,12 +29,12 @@ namespace Ipfs.Http
         {
             var o = JObject.Parse(json);
 
-            this.Sender = (string)o["from"];
-            this.SequenceNumber = Multibase.Decode((string)o["seqno"], out MultibaseEncoding _);
-            this.DataBytes = Multibase.Decode((string)o["data"], out MultibaseEncoding _);
+            this.Sender = (string?)o["from"];
+            this.SequenceNumber = Multibase.Decode((string?)o["seqno"], out MultibaseEncoding _);
+            this.DataBytes = Multibase.Decode((string?)o["data"], out MultibaseEncoding _);
 
-            var topics = (JArray) (o["topicIDs"]);
-            this.Topics = topics.Select(t => Encoding.UTF8.GetString(Multibase.Decode((string)t, out MultibaseEncoding _)));
+            var topics = (JArray?) (o["topicIDs"]);
+            this.Topics = topics.Select(t => Encoding.UTF8.GetString(Multibase.Decode((string?)t, out MultibaseEncoding _)));
         }
 
         /// <inheritdoc />

--- a/src/TrustedPeerCollection.cs
+++ b/src/TrustedPeerCollection.cs
@@ -21,11 +21,11 @@ namespace Ipfs.Http
     {
         class BootstrapListResponse
         {
-            public MultiAddress[] Peers { get; set; }
+            public MultiAddress[] Peers { get; set; } = Array.Empty<MultiAddress>();
         }
 
-        IpfsClient ipfs;
-        MultiAddress[] peers;
+        private readonly IpfsClient ipfs;
+        MultiAddress[]? peers;
 
         internal TrustedPeerCollection(IpfsClient ipfs)
         {
@@ -35,10 +35,7 @@ namespace Ipfs.Http
         /// <inheritdoc />
         public void Add(MultiAddress peer)
         {
-            if (peer == null)
-                throw new ArgumentNullException();
-
-            ipfs.DoCommandAsync("bootstrap/add", default(CancellationToken), peer.ToString()).Wait();
+            ipfs.DoCommandAsync("bootstrap/add", CancellationToken.None, peer.ToString()).Wait();
             peers = null;
         }
 
@@ -50,7 +47,7 @@ namespace Ipfs.Http
         /// </remarks>
         public void AddDefaultNodes()
         {
-            ipfs.DoCommandAsync("bootstrap/add", default(CancellationToken), null, "default=true").Wait();
+            ipfs.DoCommandAsync("bootstrap/add", CancellationToken.None, arg: null, "default=true").Wait();
             peers = null;
         }
 
@@ -62,7 +59,7 @@ namespace Ipfs.Http
         /// </remarks>
         public void Clear()
         {
-            ipfs.DoCommandAsync("bootstrap/rm", default(CancellationToken), null, "all=true").Wait();
+            ipfs.DoCommandAsync("bootstrap/rm", CancellationToken.None, arg: null, "all=true").Wait();
             peers = null;
         }
 
@@ -77,7 +74,7 @@ namespace Ipfs.Http
         public void CopyTo(MultiAddress[] array, int index)
         {
             Fetch();
-            peers.CopyTo(array, index);
+            peers!.CopyTo(array, index);
         }
 
         /// <inheritdoc />
@@ -85,7 +82,7 @@ namespace Ipfs.Http
         {
             get
             {
-                if (peers == null)
+                if (peers is null)
                     Fetch();
                 return peers.Count();
             }
@@ -105,10 +102,7 @@ namespace Ipfs.Http
         /// </remarks>
         public bool Remove(MultiAddress peer)
         {
-            if (peer == null)
-                throw new ArgumentNullException();
-
-            ipfs.DoCommandAsync("bootstrap/rm", default(CancellationToken), peer.ToString()).Wait();
+            ipfs.DoCommandAsync("bootstrap/rm", CancellationToken.None, peer.ToString()).Wait();
             peers = null;
             return true;
         }
@@ -117,19 +111,19 @@ namespace Ipfs.Http
         public IEnumerator<MultiAddress> GetEnumerator()
         {
             Fetch();
-            return ((IEnumerable<MultiAddress>)peers).GetEnumerator();
+            return ((IEnumerable<MultiAddress>)peers!).GetEnumerator();
         }
 
         /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()
         {
             Fetch();
-            return peers.GetEnumerator();
+            return peers!.GetEnumerator();
         }
 
         void Fetch()
         {
-            peers = ipfs.DoCommandAsync<BootstrapListResponse>("bootstrap/list", default(CancellationToken)).Result.Peers;
+            peers = ipfs.DoCommandAsync<BootstrapListResponse>("bootstrap/list", CancellationToken.None).GetAwaiter().GetResult().Peers;
         }
     }
 }

--- a/test/BlockTest.cs
+++ b/test/BlockTest.cs
@@ -30,6 +30,5 @@ namespace Ipfs.Http
             Assert.AreEqual(3, stream.ReadByte());
             Assert.AreEqual(-1, stream.ReadByte(), "at eof");
         }
-
     }
 }

--- a/test/CoreApi/BitswapApiTest.cs
+++ b/test/CoreApi/BitswapApiTest.cs
@@ -1,13 +1,14 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs.Http
 {
     [TestClass]
-    public class BitswapApiTest
+    public sealed class BitswapApiTest
     {
         private readonly IpfsClient ipfs = TestFixture.Ipfs;
 
@@ -15,18 +16,22 @@ namespace Ipfs.Http
         public async Task Wants()
         {
             var block = new DagNode(Encoding.UTF8.GetBytes("BitswapApiTest unknown block"));
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            Task.Run(() => ipfs.Bitswap.GetAsync(block.Id).Wait());
-
-            var endTime = DateTime.Now.AddSeconds(10);
-            while (DateTime.Now < endTime)
-            {
-                await Task.Delay(100);
-                var wants = await ipfs.Bitswap.WantsAsync();
-                if (wants.Contains(block.Id))
-                    return;
-            }
-            Assert.Fail("wanted block is missing");
+            await RunAsyncTaskAndTestAsync(
+                ct => ipfs.Bitswap.GetAsync(block.Id, ct),
+                async () =>
+                {
+                    var endTime = DateTime.Now.AddSeconds(10);
+                    while (DateTime.Now < endTime)
+                    {
+                        await Task.Delay(100);
+                        var wants = await ipfs.Bitswap.WantsAsync();
+                        if (wants.Contains(block.Id))
+                        {
+                            return;
+                        }
+                    }
+                    Assert.Fail("wanted block is missing");
+                });
         }
 
         [TestMethod]
@@ -34,31 +39,33 @@ namespace Ipfs.Http
         public async Task Unwant()
         {
             var block = new DagNode(Encoding.UTF8.GetBytes("BitswapApiTest unknown block 2"));
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            Task.Run(() => ipfs.Bitswap.GetAsync(block.Id).Wait());
+            await RunAsyncTaskAndTestAsync(
+                ct => ipfs.Bitswap.GetAsync(block.Id, ct),
+                async () =>
+                {
+                    var endTime = DateTime.Now.AddSeconds(10);
+                    while (true)
+                    {
+                        if (DateTime.Now > endTime)
+                            Assert.Fail("wanted block is missing");
+                        await Task.Delay(100);
+                        var wants = await ipfs.Bitswap.WantsAsync();
+                        if (wants.Contains(block.Id))
+                            break;
+                    }
 
-            var endTime = DateTime.Now.AddSeconds(10);
-            while (true)
-            {
-                if (DateTime.Now > endTime)
-                    Assert.Fail("wanted block is missing");
-                await Task.Delay(100);
-                var wants = await ipfs.Bitswap.WantsAsync();
-                if (wants.Contains(block.Id))
-                    break;
-            }
-
-            await ipfs.Bitswap.UnwantAsync(block.Id);
-            endTime = DateTime.Now.AddSeconds(10);
-            while (true)
-            {
-                if (DateTime.Now > endTime)
-                    Assert.Fail("unwanted block is present");
-                await Task.Delay(100);
-                var wants = await ipfs.Bitswap.WantsAsync();
-                if (!wants.Contains(block.Id))
-                    break;
-            }
+                    await ipfs.Bitswap.UnwantAsync(block.Id);
+                    endTime = DateTime.Now.AddSeconds(10);
+                    while (true)
+                    {
+                        if (DateTime.Now > endTime)
+                            Assert.Fail("unwanted block is present");
+                        await Task.Delay(100);
+                        var wants = await ipfs.Bitswap.WantsAsync();
+                        if (!wants.Contains(block.Id))
+                            break;
+                    }
+                });
         }
 
         [TestMethod]
@@ -69,6 +76,27 @@ namespace Ipfs.Http
             Assert.IsNotNull(ledger);
             Assert.IsNotNull(ledger.Peer);
             Assert.AreEqual(peer.Id, ledger.Peer!.Id);
+        }
+
+        private static async Task RunAsyncTaskAndTestAsync(Func<CancellationToken, Task> asyncTaskWork, Func<Task> testWork)
+        {
+            var cts = new CancellationTokenSource();
+            var asyncTask = Task.Run(async () => await asyncTaskWork(cts.Token));
+            try
+            {
+                await testWork();
+            }
+            finally
+            {
+                cts.Cancel();
+                try
+                {
+                    await asyncTask;
+                }
+                catch
+                {
+                }
+            }
         }
     }
 }

--- a/test/CoreApi/BitswapApiTest.cs
+++ b/test/CoreApi/BitswapApiTest.cs
@@ -1,7 +1,5 @@
-﻿using Ipfs.Http;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,7 +9,7 @@ namespace Ipfs.Http
     [TestClass]
     public class BitswapApiTest
     {
-        private IpfsClient ipfs = TestFixture.Ipfs;
+        private readonly IpfsClient ipfs = TestFixture.Ipfs;
 
         [TestMethod]
         public async Task Wants()
@@ -69,7 +67,8 @@ namespace Ipfs.Http
             var peer = new Peer { Id = "QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3" };
             var ledger = await ipfs.Bitswap.LedgerAsync(peer);
             Assert.IsNotNull(ledger);
-            Assert.AreEqual(peer.Id, ledger.Peer.Id);
+            Assert.IsNotNull(ledger.Peer);
+            Assert.AreEqual(peer.Id, ledger.Peer!.Id);
         }
     }
 }

--- a/test/CoreApi/BlockApiTest.cs
+++ b/test/CoreApi/BlockApiTest.cs
@@ -1,5 +1,4 @@
-﻿using Ipfs.Http;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Linq;
@@ -11,9 +10,9 @@ namespace Ipfs.Http
     [TestClass]
     public class BlockApiTest
     {
-        private IpfsClient ipfs = TestFixture.Ipfs;
-        private string id = "QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rAQ";
-        private byte[] blob = Encoding.UTF8.GetBytes("blorb");
+        private readonly IpfsClient ipfs = TestFixture.Ipfs;
+        private const string id = "QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rAQ";
+        private readonly byte[] blob = Encoding.UTF8.GetBytes("blorb");
 
         [TestMethod]
         public void Put_Bytes()
@@ -135,7 +134,8 @@ namespace Ipfs.Http
         {
             var _ = ipfs.Block.PutAsync(blob).Result;
             var cid = await ipfs.Block.RemoveAsync(id);
-            Assert.AreEqual(id, (string)cid);
+            Assert.IsNotNull(cid);
+            Assert.AreEqual(id, (string)cid!);
         }
 
         [TestMethod]
@@ -148,7 +148,7 @@ namespace Ipfs.Http
         public async Task Remove_Unknown_OK()
         {
             var cid = await ipfs.Block.RemoveAsync("QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rFF", true);
+            Assert.IsNull(cid);
         }
-
     }
 }

--- a/test/CoreApi/BlockApiTest.cs
+++ b/test/CoreApi/BlockApiTest.cs
@@ -11,108 +11,108 @@ namespace Ipfs.Http
     public class BlockApiTest
     {
         private readonly IpfsClient ipfs = TestFixture.Ipfs;
-        private const string id = "QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rAQ";
+        private const string id = "bafkreiaxnnnb7qz2focittuqq3ya25q7rcv3bqynnczfzako47346wosmu";
         private readonly byte[] blob = Encoding.UTF8.GetBytes("blorb");
 
         [TestMethod]
-        public void Put_Bytes()
+        public async Task Put_Bytes()
         {
-            var cid = ipfs.Block.PutAsync(blob).Result;
+            var cid = await ipfs.Block.PutAsync(blob);
             Assert.AreEqual(id, (string)cid);
 
-            var data = ipfs.Block.GetAsync(cid).Result;
+            var data = await ipfs.Block.GetAsync(cid);
             Assert.AreEqual(blob.Length, data.Size);
             CollectionAssert.AreEqual(blob, data.DataBytes);
         }
 
         [TestMethod]
-        public void Put_Bytes_ContentType()
+        public async Task Put_Bytes_ContentType()
         {
-            var cid = ipfs.Block.PutAsync(blob, contentType: "raw").Result;
+            var cid = await ipfs.Block.PutAsync(blob, contentType: "raw");
             Assert.AreEqual("bafkreiaxnnnb7qz2focittuqq3ya25q7rcv3bqynnczfzako47346wosmu", (string)cid);
 
-            var data = ipfs.Block.GetAsync(cid).Result;
+            var data = await ipfs.Block.GetAsync(cid);
             Assert.AreEqual(blob.Length, data.Size);
             CollectionAssert.AreEqual(blob, data.DataBytes);
         }
 
         [TestMethod]
-        public void Put_Bytes_Hash()
+        public async Task Put_Bytes_Hash()
         {
-            var cid = ipfs.Block.PutAsync(blob, "raw", "sha2-512").Result;
+            var cid = await ipfs.Block.PutAsync(blob, "raw", "sha2-512");
             Assert.AreEqual("bafkrgqelljziv4qfg5mefz36m2y3h6voaralnw6lwb4f53xcnrf4mlsykkn7vt6eno547tw5ygcz62kxrle45wnbmpbofo5tvu57jvuaf7k7e", (string)cid);
 
-            var data = ipfs.Block.GetAsync(cid).Result;
+            var data = await ipfs.Block.GetAsync(cid);
             Assert.AreEqual(blob.Length, data.Size);
             CollectionAssert.AreEqual(blob, data.DataBytes);
         }
 
         [TestMethod]
-        public void Put_Bytes_Pinned()
+        public async Task Put_Bytes_Pinned()
         {
             var data1 = new byte[] { 23, 24, 127 };
-            var cid1 = ipfs.Block.PutAsync(data1, contentType: "raw", pin: true).Result;
-            var pins = ipfs.Pin.ListAsync().Result;
+            var cid1 = await ipfs.Block.PutAsync(data1, contentType: "raw", pin: true);
+            var pins = await ipfs.Pin.ListAsync();
             Assert.IsTrue(pins.Any(pin => pin == cid1));
 
             var data2 = new byte[] { 123, 124, 27 };
-            var cid2 = ipfs.Block.PutAsync(data2, contentType: "raw", pin: false).Result;
-            pins = ipfs.Pin.ListAsync().Result;
+            var cid2 = await ipfs.Block.PutAsync(data2, contentType: "raw", pin: false);
+            pins = await ipfs.Pin.ListAsync();
             Assert.IsFalse(pins.Any(pin => pin == cid2));
         }
 
         [TestMethod]
-        public void Put_Stream()
+        public async Task Put_Stream()
         {
-            var cid = ipfs.Block.PutAsync(new MemoryStream(blob)).Result;
+            var cid = await ipfs.Block.PutAsync(new MemoryStream(blob));
             Assert.AreEqual(id, (string)cid);
 
-            var data = ipfs.Block.GetAsync(cid).Result;
+            var data = await ipfs.Block.GetAsync(cid);
             Assert.AreEqual(blob.Length, data.Size);
             CollectionAssert.AreEqual(blob, data.DataBytes);
         }
 
         [TestMethod]
-        public void Put_Stream_ContentType()
+        public async Task Put_Stream_ContentType()
         {
-            var cid = ipfs.Block.PutAsync(new MemoryStream(blob), contentType: "raw").Result;
+            var cid = await ipfs.Block.PutAsync(new MemoryStream(blob), contentType: "raw");
             Assert.AreEqual("bafkreiaxnnnb7qz2focittuqq3ya25q7rcv3bqynnczfzako47346wosmu", (string)cid);
 
-            var data = ipfs.Block.GetAsync(cid).Result;
+            var data = await ipfs.Block.GetAsync(cid);
             Assert.AreEqual(blob.Length, data.Size);
             CollectionAssert.AreEqual(blob, data.DataBytes);
         }
 
         [TestMethod]
-        public void Put_Stream_Hash()
+        public async Task Put_Stream_Hash()
         {
-            var cid = ipfs.Block.PutAsync(new MemoryStream(blob), "raw", "sha2-512").Result;
+            var cid = await ipfs.Block.PutAsync(new MemoryStream(blob), "raw", "sha2-512");
             Assert.AreEqual("bafkrgqelljziv4qfg5mefz36m2y3h6voaralnw6lwb4f53xcnrf4mlsykkn7vt6eno547tw5ygcz62kxrle45wnbmpbofo5tvu57jvuaf7k7e", (string)cid);
 
-            var data = ipfs.Block.GetAsync(cid).Result;
+            var data = await ipfs.Block.GetAsync(cid);
             Assert.AreEqual(blob.Length, data.Size);
             CollectionAssert.AreEqual(blob, data.DataBytes);
         }
 
         [TestMethod]
-        public void Put_Stream_Pinned()
+        public async Task Put_Stream_Pinned()
         {
             var data1 = new MemoryStream(new byte[] { 23, 24, 127 });
-            var cid1 = ipfs.Block.PutAsync(data1, contentType: "raw", pin: true).Result;
-            var pins = ipfs.Pin.ListAsync().Result;
+            var cid1 = await ipfs.Block.PutAsync(data1, contentType: "raw", pin: true);
+            var pins = await ipfs.Pin.ListAsync();
             Assert.IsTrue(pins.Any(pin => pin == cid1));
 
             var data2 = new MemoryStream(new byte[] { 123, 124, 27 });
-            var cid2 = ipfs.Block.PutAsync(data2, contentType: "raw", pin: false).Result;
-            pins = ipfs.Pin.ListAsync().Result;
+            var cid2 = await ipfs.Block.PutAsync(data2, contentType: "raw", pin: false);
+            pins = await ipfs.Pin.ListAsync();
             Assert.IsFalse(pins.Any(pin => pin == cid2));
         }
 
         [TestMethod]
-        public void Get()
+        public async Task Get()
         {
-            var _ = ipfs.Block.PutAsync(blob).Result;
-            var block = ipfs.Block.GetAsync(id).Result;
+            var _ = await ipfs.Block.PutAsync(blob);
+            var block = await ipfs.Block.GetAsync(id);
             Assert.AreEqual(id, (string)block.Id);
             CollectionAssert.AreEqual(blob, block.DataBytes);
             var blob1 = new byte[blob.Length];
@@ -121,10 +121,10 @@ namespace Ipfs.Http
         }
 
         [TestMethod]
-        public void Stat()
+        public async Task Stat()
         {
-            var _ = ipfs.Block.PutAsync(blob).Result;
-            var info = ipfs.Block.StatAsync(id).Result;
+            var _ = await ipfs.Block.PutAsync(blob);
+            var info = await ipfs.Block.StatAsync(id);
             Assert.AreEqual(id, (string)info.Id);
             Assert.AreEqual(5, info.Size);
         }
@@ -132,7 +132,7 @@ namespace Ipfs.Http
         [TestMethod]
         public async Task Remove()
         {
-            var _ = ipfs.Block.PutAsync(blob).Result;
+            var _ = await ipfs.Block.PutAsync(blob);
             var cid = await ipfs.Block.RemoveAsync(id);
             Assert.IsNotNull(cid);
             Assert.AreEqual(id, (string)cid!);
@@ -141,13 +141,13 @@ namespace Ipfs.Http
         [TestMethod]
         public void Remove_Unknown()
         {
-            ExceptionAssert.Throws<Exception>(() => { var _ = ipfs.Block.RemoveAsync("QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rFF").Result; });
+            ExceptionAssert.Throws<Exception>(() => { var _ = ipfs.Block.RemoveAsync("QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rFF").GetAwaiter().GetResult(); });
         }
 
         [TestMethod]
         public async Task Remove_Unknown_OK()
         {
-            var cid = await ipfs.Block.RemoveAsync("QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rFF", true);
+            var cid = await ipfs.Block.RemoveAsync("QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rFF", ignoreNonexistent: true);
             Assert.IsNull(cid);
         }
     }

--- a/test/CoreApi/BlockRepositoryTest.cs
+++ b/test/CoreApi/BlockRepositoryTest.cs
@@ -21,6 +21,5 @@ namespace Ipfs.Http
             var version = await ipfs.BlockRepository.VersionAsync();
             Assert.IsFalse(string.IsNullOrWhiteSpace(version));
         }
-
     }
 }

--- a/test/CoreApi/BootstrapTest.cs
+++ b/test/CoreApi/BootstrapTest.cs
@@ -7,8 +7,8 @@ namespace Ipfs.Http
     [TestClass]
     public class BootstapApiTest
     {
-        IpfsClient ipfs = TestFixture.Ipfs;
-        MultiAddress somewhere = "/ip4/127.0.0.1/tcp/4009/ipfs/QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rAQ";
+        private readonly IpfsClient ipfs = TestFixture.Ipfs;
+        private readonly MultiAddress somewhere = "/ip4/127.0.0.1/tcp/4009/ipfs/QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rAQ";
 
         [TestMethod]
         public async Task Add_Remove()

--- a/test/CoreApi/ConfigApiTest.cs
+++ b/test/CoreApi/ConfigApiTest.cs
@@ -16,7 +16,7 @@ namespace Ipfs.Http
         {
             IpfsClient ipfs = TestFixture.Ipfs;
             var config = ipfs.Config.GetAsync().Result;
-            StringAssert.StartsWith(config["Addresses"]["API"].Value<string>(), apiAddress);
+            StringAssert.StartsWith(config["Addresses"]!["API"]!.Value<string>(), apiAddress);
         }
 
         [TestMethod]
@@ -32,8 +32,8 @@ namespace Ipfs.Http
         {
             IpfsClient ipfs = TestFixture.Ipfs;
             var addresses = ipfs.Config.GetAsync("Addresses").Result;
-            StringAssert.StartsWith(addresses["API"].Value<string>(), apiAddress);
-            StringAssert.StartsWith(addresses["Gateway"].Value<string>(), gatewayAddress);
+            StringAssert.StartsWith(addresses["API"]!.Value<string>(), apiAddress);
+            StringAssert.StartsWith(addresses["Gateway"]!.Value<string>(), gatewayAddress);
         }
 
         [TestMethod]

--- a/test/CoreApi/DagApiTest.cs
+++ b/test/CoreApi/DagApiTest.cs
@@ -9,9 +9,9 @@ namespace Ipfs.Http
     {
         class Name
         {
-            public string First { get; set; }
+            public string? First { get; set; }
 
-            public string Last { get; set; }
+            public string? Last { get; set; }
         }
 
         [TestMethod]
@@ -29,7 +29,7 @@ namespace Ipfs.Http
             Assert.IsNotNull(actual);
             Assert.AreEqual(expected["a"], actual["a"]);
 
-            var value = (string)await ipfs.Dag.GetAsync(expectedId + "/a");
+            var value = (string?)await ipfs.Dag.GetAsync(expectedId + "/a");
             Assert.AreEqual(expected["a"], value);
         }
 
@@ -46,7 +46,7 @@ namespace Ipfs.Http
             Assert.AreEqual(expected.First, actual.First);
             Assert.AreEqual(expected.Last, actual.Last);
 
-            var value = (string)await ipfs.Dag.GetAsync(id.Encode() + "/Last");
+            var value = (string?)await ipfs.Dag.GetAsync(id.Encode() + "/Last");
             Assert.AreEqual(expected.Last, value);
         }
     }

--- a/test/CoreApi/DagApiTest.cs
+++ b/test/CoreApi/DagApiTest.cs
@@ -43,7 +43,7 @@ namespace Ipfs.Http
 
             var actual = await ipfs.Dag.GetAsync<Name>(id);
             Assert.IsNotNull(actual);
-            Assert.AreEqual(expected.First, actual.First);
+            Assert.AreEqual(expected.First, actual!.First);
             Assert.AreEqual(expected.Last, actual.Last);
 
             var value = (string?)await ipfs.Dag.GetAsync(id.Encode() + "/Last");

--- a/test/CoreApi/KeyApiTest.cs
+++ b/test/CoreApi/KeyApiTest.cs
@@ -61,7 +61,7 @@ namespace Ipfs.Http
 
             var removed = await ipfs.Key.RemoveAsync(name);
             Assert.IsNotNull(removed);
-            Assert.AreEqual(key.Name, removed.Name);
+            Assert.AreEqual(key.Name, removed!.Name);
             Assert.AreEqual(key.Id, removed.Id);
 
             keys = await ipfs.Key.ListAsync();

--- a/test/CoreApi/SwarmApiTest.cs
+++ b/test/CoreApi/SwarmApiTest.cs
@@ -60,9 +60,10 @@ namespace Ipfs.Http
             // tests that a connection can be made to at least one peer.
             foreach (var peer in peers.Take(2))
             {
+                Assert.IsNotNull(peer.ConnectedAddress);
                 try
                 {
-                    await ipfs.Swarm.ConnectAsync(peer.ConnectedAddress);
+                    await ipfs.Swarm.ConnectAsync(peer.ConnectedAddress!);
                     return;
                 }
                 catch (Exception)

--- a/test/ExceptionAssert.cs
+++ b/test/ExceptionAssert.cs
@@ -9,7 +9,7 @@ namespace Ipfs.Http
     /// </summary>
     public static class ExceptionAssert
     {
-        public static T Throws<T>(Action action, string expectedMessage = null) where T : Exception
+        public static T Throws<T>(Action action, string? expectedMessage = null) where T : Exception
         {
             try
             {
@@ -18,9 +18,9 @@ namespace Ipfs.Http
             catch (AggregateException e)
             {
                 var match = e.InnerExceptions.OfType<T>().FirstOrDefault();
-                if (match != null)
+                if (match is not null)
                 {
-                    if (expectedMessage != null)
+                    if (expectedMessage is not null)
                         Assert.AreEqual(expectedMessage, match.Message, "Wrong exception message.");
                     return match;
                 }
@@ -29,17 +29,17 @@ namespace Ipfs.Http
             }
             catch (T e)
             {
-                if (expectedMessage != null)
+                if (expectedMessage is not null)
                     Assert.AreEqual(expectedMessage, e.Message);
                 return e;
             }
             Assert.Fail("Exception of type {0} should be thrown.", typeof(T));
 
             //  The compiler doesn't know that Assert.Fail will always throw an exception
-            return null;
+            throw new Exception();
         }
 
-        public static Exception Throws(Action action, string expectedMessage = null)
+        public static Exception Throws(Action action, string? expectedMessage = null)
         {
             return Throws<Exception>(action, expectedMessage);
         }

--- a/test/FileSystemNodeTest.cs
+++ b/test/FileSystemNodeTest.cs
@@ -18,7 +18,8 @@ namespace Ipfs.Http
             var b = await ipfs.FileSystem.ListFileAsync(a.Id);
             var json = JsonConvert.SerializeObject(b);
             var c = JsonConvert.DeserializeObject<FileSystemNode>(json);
-            Assert.AreEqual(b.Id, c.Id);
+            Assert.IsNotNull(c);
+            Assert.AreEqual(b.Id, c!.Id);
             Assert.AreEqual(b.IsDirectory, c.IsDirectory);
             Assert.AreEqual(b.Size, c.Size);
             CollectionAssert.AreEqual(b.Links.ToArray(), c.Links.ToArray());

--- a/test/IpfsHttpClientTests.csproj
+++ b/test/IpfsHttpClientTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <DebugType>full</DebugType>
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MerkleNodeTest.cs
+++ b/test/MerkleNodeTest.cs
@@ -35,9 +35,9 @@ namespace Ipfs.Http
         [TestMethod]
         public void NullHash()
         {
-            ExceptionAssert.Throws<ArgumentNullException>(() => new MerkleNode((string)null));
+            ExceptionAssert.Throws<ArgumentNullException>(() => new MerkleNode((string)null!));
             ExceptionAssert.Throws<ArgumentNullException>(() => new MerkleNode(""));
-            ExceptionAssert.Throws<ArgumentNullException>(() => new MerkleNode((Cid)null));
+            ExceptionAssert.Throws<ArgumentNullException>(() => new MerkleNode((Cid)null!));
         }
 
         [TestMethod]
@@ -67,19 +67,19 @@ namespace Ipfs.Http
             var a0 = new MerkleNode("QmStfpa7ppKPSsdnazBy3Q5QH4zNzGLcpWV88otjVSV7SY");
             var a1 = new MerkleNode("QmStfpa7ppKPSsdnazBy3Q5QH4zNzGLcpWV88otjVSV7SY");
             var b = new MerkleNode("QmagNHT6twJRBZcGeviiGzHVTMbNnJZameLyL6T14GUHCS");
-            MerkleNode nullNode = null;
+            MerkleNode? nullNode = null;
 
 #pragma warning disable 1718
             Assert.IsTrue(a0 == a0);
             Assert.IsTrue(a0 == a1);
             Assert.IsFalse(a0 == b);
-            Assert.IsFalse(a0 == null);
+            Assert.IsNotNull(a0);
 
 #pragma warning disable 1718
             Assert.IsFalse(a0 != a0);
             Assert.IsFalse(a0 != a1);
             Assert.IsTrue(a0 != b);
-            Assert.IsTrue(a0 != null);
+            Assert.IsNotNull(a0);
 
             Assert.IsTrue(a0.Equals(a0));
             Assert.IsTrue(a0.Equals(a1));
@@ -89,21 +89,21 @@ namespace Ipfs.Http
             Assert.AreEqual(a0, a0);
             Assert.AreEqual(a0, a1);
             Assert.AreNotEqual(a0, b);
-            Assert.AreNotEqual(a0, null);
+            Assert.IsNotNull(a0);
 
-            Assert.AreEqual<MerkleNode>(a0, a0);
-            Assert.AreEqual<MerkleNode>(a0, a1);
-            Assert.AreNotEqual<MerkleNode>(a0, b);
-            Assert.AreNotEqual<MerkleNode>(a0, null);
+            Assert.AreEqual<MerkleNode>(a0!, a0!);
+            Assert.AreEqual<MerkleNode>(a0!, a1);
+            Assert.AreNotEqual<MerkleNode>(a0!, b);
+            Assert.AreNotEqual<MerkleNode>(a0!, null!);
 
-            Assert.AreEqual(a0.GetHashCode(), a0.GetHashCode());
+            Assert.AreEqual(a0!.GetHashCode(), a0.GetHashCode());
             Assert.AreEqual(a0.GetHashCode(), a1.GetHashCode());
             Assert.AreNotEqual(a0.GetHashCode(), b.GetHashCode());
 
-            Assert.IsTrue(nullNode == null);
-            Assert.IsFalse(null == a0);
-            Assert.IsFalse(nullNode != null);
-            Assert.IsTrue(null != a0);
+            Assert.IsNull(nullNode);
+            Assert.IsNotNull(a0);
+            Assert.IsNull(nullNode);
+            Assert.IsNotNull(a0);
         }
 
         [TestMethod]

--- a/test/MerkleNodeTest.cs
+++ b/test/MerkleNodeTest.cs
@@ -36,8 +36,7 @@ namespace Ipfs.Http
         public void NullHash()
         {
             ExceptionAssert.Throws<ArgumentNullException>(() => new MerkleNode((string)null!));
-            ExceptionAssert.Throws<ArgumentNullException>(() => new MerkleNode(""));
-            ExceptionAssert.Throws<ArgumentNullException>(() => new MerkleNode((Cid)null!));
+            ExceptionAssert.Throws<ArgumentNullException>(() => new MerkleNode(string.Empty));
         }
 
         [TestMethod]

--- a/test/PublishedMessageTest.cs
+++ b/test/PublishedMessageTest.cs
@@ -40,6 +40,5 @@ namespace Ipfs.Http
                 var _ = msg.Id;
             });
         }
-
     }
 }


### PR DESCRIPTION
For #20, utilizing a locally published version of the nullable IpfsShipyard.Ipfs.Core.dll from https://github.com/ipfs-shipyard/net-ipfs-core/pull/21 . Remove some ArgumentNullException where nullability covers it to reduce runtime code (this is a change to public surface area, can be reverted - see changes in unit tests). Some opportunistic code cleanup ahead of #8 .