### PR TITLE
Cidv1 support for libp2p-key

### DIFF
--- a/src/CoreApi/KeyApi.cs
+++ b/src/CoreApi/KeyApi.cs
@@ -16,7 +16,7 @@ namespace Ipfs.Http
         public class KeyInfo : IKey
         {
             /// <inheritdoc />
-            public MultiHash Id { get; set; }
+            public Cid Id { get; set; }
 
             /// <inheritdoc />
             public string Name { get; set; }
@@ -37,7 +37,7 @@ namespace Ipfs.Http
 
         public async Task<IKey> CreateAsync(string name, string keyType, int size, CancellationToken cancel = default(CancellationToken))
         {
-            var json = await ipfs.DoCommandAsync("key/gen", cancel, name, $"type={keyType}", $"size={size}", "ipns-base=base32");
+            var json = await ipfs.DoCommandAsync("key/gen", cancel, name, $"type={keyType}", $"size={size}", "ipns-base=base36");
             var jobject = JObject.Parse(json);
 
             string id = (string)jobject["Id"];
@@ -45,14 +45,14 @@ namespace Ipfs.Http
 
             return new KeyInfo
             {
-                Id = Cid.Decode(id).Hash,
+                Id = id,
                 Name = apiName
             };
         }
 
         public async Task<IEnumerable<IKey>> ListAsync(CancellationToken cancel = default(CancellationToken))
         {
-            var json = await ipfs.DoCommandAsync("key/list", cancel, null, "l=true", "ipns-base=base32");
+            var json = await ipfs.DoCommandAsync("key/list", cancel, null, "l=true", "ipns-base=base36");
             var keys = (JArray)(JObject.Parse(json)["Keys"]);
 
             return keys
@@ -63,7 +63,7 @@ namespace Ipfs.Http
 
                     return new KeyInfo
                     {
-                        Id = Cid.Decode(id).Hash,
+                        Id = id,
                         Name = name
                     };
                 });
@@ -71,7 +71,7 @@ namespace Ipfs.Http
 
         public async Task<IKey> RemoveAsync(string name, CancellationToken cancel = default(CancellationToken))
         {
-            var json = await ipfs.DoCommandAsync("key/rm", cancel, name, "ipns-base=base32");
+            var json = await ipfs.DoCommandAsync("key/rm", cancel, name, "ipns-base=base36");
             var keys = JObject.Parse(json)["Keys"] as JArray;
 
             return keys?
@@ -82,7 +82,7 @@ namespace Ipfs.Http
 
                         return new KeyInfo
                         {
-                            Id = Cid.Decode(id).Hash,
+                            Id = id,
                             Name = keyName
                         };
                     })
@@ -91,7 +91,7 @@ namespace Ipfs.Http
 
         public async Task<IKey> RenameAsync(string oldName, string newName, CancellationToken cancel = default(CancellationToken))
         {
-            var json = await ipfs.DoCommandAsync("key/rename", cancel, oldName, $"arg={newName}", "ipns-base=base32");
+            var json = await ipfs.DoCommandAsync("key/rename", cancel, oldName, $"arg={newName}", "ipns-base=base36");
             var jobject = JObject.Parse(json);
 
             string id = (string)jobject["Id"];
@@ -99,7 +99,7 @@ namespace Ipfs.Http
 
             return new KeyInfo
             {
-                Id = Cid.Decode(id).Hash,
+                Id = id,
                 Name = currentName
             };
         }

--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -9,7 +9,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- https://semver.org/spec/v2.0.0.html -->
-    <Version>0.0.8</Version>
+    <Version>0.1.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
 
     <!-- Nuget specs -->
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.0.5" />
+    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.1.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Multiformats.Base" Version="2.0.2" />

--- a/test/CoreApi/NameApiTest.cs
+++ b/test/CoreApi/NameApiTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,18 +25,19 @@ namespace Ipfs.Http
         }
 
         [TestMethod]
-        [Ignore("takes forever")]
         public async Task Publish()
         {
             var ipfs = TestFixture.Ipfs;
             var cs = new CancellationTokenSource(TimeSpan.FromMinutes(5));
             var content = await ipfs.FileSystem.AddTextAsync("hello world");
-            var key = await ipfs.Key.CreateAsync("name-publish-test", "rsa", 1024);
+            var key = await ipfs.Key.CreateAsync("name-publish-test", "rsa", 2048);
+
             try
             {
                 var result = await ipfs.Name.PublishAsync(content.Id, key.Name, cancel: cs.Token);
                 Assert.IsNotNull(result);
-                StringAssert.EndsWith(result.NamePath, key.Id.ToString());
+
+                StringAssert.EndsWith(result.NamePath, key.Id);
                 StringAssert.EndsWith(result.ContentPath, content.Id.Encode());
             }
             finally


### PR DESCRIPTION
## Background 

Since this code was written in 2019, the ipfs ecosystem has moved to using base36 Cidv1 as the default for the libp2p-key multihashes used for public peer ids and ipns public keys (see [RFC0001](https://github.com/libp2p/specs/pull/209)).

## Changes

Brings us up to speed with the latest defaults in Kubo's Key API.

- Support for Multicodec `libp2p-key` (0x72) was added.
- Support for Base36 was added, as it's the default used in Kubo's Key API. This was ported from the [`go-base36`](https://github.com/multiformats/go-base36/blob/v0.2.0/base36.go) used by Boxo and Kubo.
- `IKey.Id` is now a Cid instead of a MultiHash, allowing support for both Cidv0 and Cidv1. Using MultiHash here would force dropping essential Cidv1 information, and only supports implicitly base58btc encoded Cidv0.  


