### PR TITLE
Release 0.3.0. Update dependencies.

### DIFF
--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -9,7 +9,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- https://semver.org/spec/v2.0.0.html -->
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <LangVersion>12.0</LangVersion>
 
@@ -41,6 +41,14 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb;$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PackageReleaseNotes>
+--- 0.3.0 ---
+[Breaking]
+No breaking changes for code in this library.
+Inherited breaking changes from IpfsShipyard.Ipfs.Core 0.4.0. See release notes for details.
+
+[Improvements]
+Updated all package dependencies to latest version.
+
 --- 0.2.0 ---
 [Breaking]
 Inherited breaking changes from IpfsShipyard.Ipfs.Core 0.2.0 and 0.3.0.
@@ -57,7 +65,7 @@ Added missing IFileSystemApi.ListAsync. Doesn't fully replace the removed IFileS
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.3.0" />
+    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Multiformats.Base" Version="2.0.2" />

--- a/test/IpfsHttpClientTests.csproj
+++ b/test/IpfsHttpClientTests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates dependencies, including the changes to IpfsShipyard.Ipfs.Net.Core 0.4.0.

The IMfs implementation was added in a previous update, but it was not added to ICoreApi.

See also https://github.com/ipfs-shipyard/net-ipfs-http-client/pull/16