### PR TITLE
Added missing Flush property to MfsWriteOptions

### DIFF
--- a/src/CoreApi/MfsApi.cs
+++ b/src/CoreApi/MfsApi.cs
@@ -211,6 +211,8 @@ namespace Ipfs.Http
                 opts.Add($"raw-leaves={options.RawLeaves.ToString().ToLower()}");
             if (options.Hash != null && options.Hash != MultiHash.DefaultAlgorithmName)
                 opts.Add($"hash=${options.Hash}");
+            if (options.Flush.HasValue)
+                opts.Add($"flush={options.Flush.ToString().ToLower()}");
 
             if (string.IsNullOrEmpty(path) || !path.StartsWith("/"))
                 throw new ArgumentException("Argument path is required and must start with '/'.");

--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -77,7 +77,7 @@ Added missing IFileSystemApi.ListAsync. Doesn't fully replace the removed IFileS
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.6.0" />
+    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.6.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Multiformats.Base" Version="2.0.2" />

--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -9,7 +9,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- https://semver.org/spec/v2.0.0.html -->
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <LangVersion>12.0</LangVersion>
 
@@ -41,6 +41,13 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb;$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PackageReleaseNotes>
+--- 0.5.1 ---
+[New]
+Added support for MfsWriteOptions.Flush in MfsApi.WriteAsync.
+
+[Improvements]
+Updated to IpfsShipyard.Ipfs.Core 0.6.1.
+
 --- 0.5.0 ---
 [Breaking]
 Inherited breaking changes from IpfsShipyard.Ipfs.Core 0.6.0. See release notes for details.


### PR DESCRIPTION
Implementing https://github.com/ipfs-shipyard/net-ipfs-core/pull/38

- **Added support for MfsWriteOptions.Flush in MfsApi.WriteAsync.**
- **Update version to 0.5.1, added release notes.**
