### PR TITLE
Added new API entry point to be able to use the API call type parameter.

### DIFF
--- a/src/CoreApi/PinApi.cs
+++ b/src/CoreApi/PinApi.cs
@@ -1,4 +1,5 @@
-﻿using Ipfs.CoreApi;
+﻿using Google.Protobuf;
+using Ipfs.CoreApi;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,6 +28,18 @@ namespace Ipfs.Http
         public async Task<IEnumerable<Cid>> ListAsync(CancellationToken cancel = default(CancellationToken))
         {
             var json = await ipfs.DoCommandAsync("pin/ls", cancel);
+            var keys = (JObject)(JObject.Parse(json)["Keys"]);
+            return keys
+                .Properties()
+                .Select(p => (Cid)p.Name);
+        }
+
+        public async Task<IEnumerable<Cid>> ListAsync(PinType type, CancellationToken cancel = default(CancellationToken))
+        {
+            var typeOpt = type.ToString().ToLowerInvariant();
+            var json = await ipfs.DoCommandAsync("pin/ls", cancel,
+                null,
+                $"type={typeOpt}");
             var keys = (JObject)(JObject.Parse(json)["Keys"]);
             return keys
                 .Properties()


### PR DESCRIPTION
This needs PR https://github.com/ipfs-shipyard/net-ipfs-core/pull/47#issue-3216774382 to be accepted before it can compile. I wanted to be able to list pins by type, which is included in Kubo API, but not in the C# API. I added the necessary entry point and data structure needed in CoreApi, and added the API call here.

Hope it's all fine, it's one of if not my first time doing PRs.