### PR TITLE
Pin API alignment: option and response records, streaming/progress options

### DIFF
--- a/src/CoreApi/FileSystemApi.cs
+++ b/src/CoreApi/FileSystemApi.cs
@@ -270,7 +270,7 @@ namespace Ipfs.Http
                 opts.Add($"nocopy={options.NoCopy.ToString().ToLowerInvariant()}");
 
             if (options.Pin is not null)
-                opts.Add("pin=false");
+                opts.Add($"pin={options.Pin.ToString().ToLowerInvariant()}");
 
             if (options.Wrap is not null)
                 opts.Add($"wrap-with-directory={options.Wrap.ToString().ToLowerInvariant()}");

--- a/src/CoreApi/FileSystemApi.cs
+++ b/src/CoreApi/FileSystemApi.cs
@@ -271,6 +271,9 @@ namespace Ipfs.Http
 
             if (options.Pin is not null)
                 opts.Add($"pin={options.Pin.ToString().ToLowerInvariant()}");
+                
+            if (!string.IsNullOrEmpty(options.PinName))
+                opts.Add($"pin-name={options.PinName}");
 
             if (options.Wrap is not null)
                 opts.Add($"wrap-with-directory={options.Wrap.ToString().ToLowerInvariant()}");
@@ -291,10 +294,10 @@ namespace Ipfs.Http
                 opts.Add("progress=true");
 
             if (options.Hash is not null)
-                opts.Add($"hash=${options.Hash}");
+                opts.Add($"hash={options.Hash}");
 
             if (options.FsCache is not null)
-                opts.Add($"fscache={options.Wrap.ToString().ToLowerInvariant()}");
+                opts.Add($"fscache={options.FsCache.ToString().ToLowerInvariant()}");
 
             if (options.ToFiles is not null)
                 opts.Add($"to-files={options.ToFiles}");

--- a/src/CoreApi/PinApi.cs
+++ b/src/CoreApi/PinApi.cs
@@ -1,12 +1,13 @@
-﻿using Google.Protobuf;
-using Ipfs.CoreApi;
-using Newtonsoft.Json.Linq;
+﻿using Ipfs.CoreApi;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System;
+using System.IO;
+using Newtonsoft.Json;
 
+#nullable enable
 namespace Ipfs.Http
 {
     class PinApi : IPinApi
@@ -30,36 +31,162 @@ namespace Ipfs.Http
                 optList.Add("name=" + options.Name);
             }
             var json = await ipfs.DoCommandAsync("pin/add", cancel, path, optList.ToArray());
-            return ((JArray)JObject.Parse(json)["Pins"]) .Select(p => (Cid)(string)p);
+            var dto = JsonConvert.DeserializeObject<PinChangeResponseDto>(json);
+            var pins = dto?.Pins ?? new List<string>();
+            return pins.Select(p => (Cid)p);
         }
 
-        public async Task<IEnumerable<Cid>> ListAsync(CancellationToken cancel = default)
+        public async Task<IEnumerable<Cid>> AddAsync(string path, PinAddOptions options, IProgress<BlocksPinnedProgress> progress, CancellationToken cancel = default)
         {
-            var json = await ipfs.DoCommandAsync("pin/ls", cancel);
-            var keys = (JObject)(JObject.Parse(json)["Keys"]);
-            return keys
-                .Properties()
-                .Select(p => (Cid)p.Name);
+            options ??= new PinAddOptions();
+            var optList = new List<string>
+            {
+                "recursive=" + options.Recursive.ToString().ToLowerInvariant(),
+                "progress=true"
+            };
+            if (!string.IsNullOrEmpty(options.Name))
+            {
+                optList.Add("name=" + options.Name);
+            }
+            var pinned = new List<Cid>();
+            var stream = await ipfs.PostDownloadAsync("pin/add", cancel, path, optList.ToArray());
+            using var sr = new StreamReader(stream);
+            while (!sr.EndOfStream && !cancel.IsCancellationRequested)
+            {
+                var line = await sr.ReadLineAsync();
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+                var dto = JsonConvert.DeserializeObject<PinChangeResponseDto>(line);
+                if (dto is null)
+                    continue;
+                if (dto.Progress.HasValue)
+                {
+                    progress?.Report(new BlocksPinnedProgress { BlocksPinned = dto.Progress.Value });
+                }
+                if (dto.Pins != null)
+                {
+                    foreach (var p in dto.Pins)
+                    {
+                        pinned.Add((Cid)p);
+                    }
+                }
+            }
+            return pinned;
         }
 
-        public async Task<IEnumerable<Cid>> ListAsync(PinType type, CancellationToken cancel = default(CancellationToken))
+        public async IAsyncEnumerable<PinListItem> ListAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancel = default)
         {
-            var typeOpt = type.ToString().ToLowerInvariant();
-            var json = await ipfs.DoCommandAsync("pin/ls", cancel,
-                null,
-                $"type={typeOpt}");
-            var keys = (JObject)(JObject.Parse(json)["Keys"]);
-            return keys
-                .Properties()
-                .Select(p => (Cid)p.Name);
+            // Default non-streaming, no names
+            foreach (var item in await ListItemsOnceAsync(null, new List<string>(), cancel))
+            {
+                yield return item;
+            }
+        }
+
+        public async IAsyncEnumerable<PinListItem> ListAsync(PinType type, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancel = default)
+        {
+            var opts = new List<string> { $"type={type.ToString().ToLowerInvariant()}" };
+            foreach (var item in await ListItemsOnceAsync(null, opts, cancel))
+            {
+                yield return item;
+            }
+        }
+
+        public async IAsyncEnumerable<PinListItem> ListAsync(PinListOptions options, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancel = default)
+        {
+            options ??= new PinListOptions();
+            var opts = new List<string>();
+            if (options.Type != PinType.All)
+                opts.Add($"type={options.Type.ToString().ToLowerInvariant()}");
+            if (!string.IsNullOrEmpty(options.Name))
+            {
+                opts.Add($"name={options.Name}");
+                opts.Add("names=true");
+            }
+            else if (options.Names)
+            {
+                opts.Add("names=true");
+            }
+
+            if (options.Stream)
+            {
+                await foreach (var item in ListItemsStreamAsync(null, opts, options.Names, cancel))
+                {
+                    yield return item;
+                }
+            }
+            else
+            {
+                foreach (var item in await ListItemsOnceAsync(null, opts, cancel))
+                {
+                    yield return item;
+                }
+            }
         }
 
         public async Task<IEnumerable<Cid>> RemoveAsync(Cid id, bool recursive = true, CancellationToken cancel = default(CancellationToken))
         {
             var opts = "recursive=" + recursive.ToString().ToLowerInvariant();
             var json = await ipfs.DoCommandAsync("pin/rm", cancel, id, opts);
-            return ((JArray)JObject.Parse(json)["Pins"])
-                .Select(p => (Cid)(string)p);
+            var dto = JsonConvert.DeserializeObject<PinChangeResponseDto>(json);
+            var pins = dto?.Pins ?? new List<string>();
+            return pins.Select(p => (Cid)p);
+        }
+
+    // Internal helper used by ListAsync overloads
+
+        async IAsyncEnumerable<PinListItem> ListItemsStreamAsync(string? path, List<string> opts, bool includeNames, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancel)
+        {
+            opts = new List<string>(opts) { "stream=true" };
+            var stream = await ipfs.PostDownloadAsync("pin/ls", cancel, path, opts.ToArray());
+            using var sr = new StreamReader(stream);
+            while (!sr.EndOfStream && !cancel.IsCancellationRequested)
+            {
+                var line = await sr.ReadLineAsync();
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+                var dto = JsonConvert.DeserializeObject<PinLsObjectDto>(line);
+                if (dto is null || string.IsNullOrEmpty(dto.Cid))
+                    continue;
+                yield return new PinListItem
+                {
+                    Cid = (Cid)dto.Cid!,
+                    Type = ParseType(dto.Type),
+                    Name = dto.Name
+                };
+            }
+        }
+
+        async Task<IEnumerable<PinListItem>> ListItemsOnceAsync(string? path, List<string> opts, CancellationToken cancel)
+        {
+            var json = await ipfs.DoCommandAsync("pin/ls", cancel, path, opts.ToArray());
+            var root = JsonConvert.DeserializeObject<PinListResponseDto>(json);
+            var list = new List<PinListItem>();
+            if (root?.Keys != null)
+            {
+                foreach (var kv in root.Keys)
+                {
+                    list.Add(new PinListItem
+                    {
+                        Cid = (Cid)kv.Key!,
+                        Type = ParseType(kv.Value?.Type),
+                        Name = string.IsNullOrEmpty(kv.Value?.Name) ? null : kv.Value!.Name
+                    });
+                }
+            }
+            return list;
+        }
+
+        static PinType ParseType(string? t)
+        {
+            return t?.ToLowerInvariant() switch
+            {
+                "direct" => PinType.Direct,
+                "indirect" => PinType.Indirect,
+                "recursive" => PinType.Recursive,
+                "all" => PinType.All,
+                _ => PinType.All
+            };
         }
 
     }

--- a/src/CoreApi/PinDto.cs
+++ b/src/CoreApi/PinDto.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+#nullable enable
+namespace Ipfs.Http
+{
+    /// <summary>
+    ///   Non-streaming response DTO for /api/v0/pin/ls.
+    /// </summary>
+    internal record PinListResponseDto
+    {
+        public Dictionary<string, PinInfoDto>? Keys { get; init; }
+    }
+
+    /// <summary>
+    ///   DTO for entry value in PinListResponseDto.Keys.
+    /// </summary>
+    internal record PinInfoDto
+    {
+        public string? Name { get; init; }
+        public string? Type { get; init; }
+    }
+
+    /// <summary>
+    ///   Streaming response DTO for /api/v0/pin/ls?stream=true.
+    /// </summary>
+    internal record PinLsObjectDto
+    {
+        public string? Cid { get; init; }
+        public string? Name { get; init; }
+        public string? Type { get; init; }
+    }
+
+    /// <summary>
+    ///   Response DTO for /api/v0/pin/add and /api/v0/pin/rm which both return a Pins array.
+    /// </summary>
+    internal record PinChangeResponseDto
+    {
+    public int? Progress { get; init; }
+        public List<string>? Pins { get; init; }
+    }
+}

--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -102,7 +102,7 @@ Added missing IFileSystemApi.ListAsync. Doesn't fully replace the removed IFileS
   </ItemGroup>
 
   <ItemGroup>
-  <ProjectReference Include="..\..\net-ipfs-core\src\IpfsCore.csproj" />
+    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Multiformats.Base" Version="2.0.2" />

--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -102,7 +102,7 @@ Added missing IFileSystemApi.ListAsync. Doesn't fully replace the removed IFileS
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IpfsShipyard.Ipfs.Core" Version="0.7.0" />
+  <ProjectReference Include="..\..\net-ipfs-core\src\IpfsCore.csproj" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Multiformats.Base" Version="2.0.2" />

--- a/test/AsyncEnumerableTestHelpers.cs
+++ b/test/AsyncEnumerableTestHelpers.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Ipfs.Http
+{
+    internal static class AsyncEnumerableTestHelpers
+    {
+        public static IEnumerable<T> ToEnumerable<T>(this IAsyncEnumerable<T> source)
+        {
+            return source.ToArrayAsync().GetAwaiter().GetResult();
+        }
+
+        public static async Task<T[]> ToArrayAsync<T>(this IAsyncEnumerable<T> source)
+        {
+            var list = new List<T>();
+            await foreach (var item in source)
+            {
+                list.Add(item);
+            }
+            return list.ToArray();
+        }
+    }
+}

--- a/test/CoreApi/BlockApiTest.cs
+++ b/test/CoreApi/BlockApiTest.cs
@@ -59,13 +59,13 @@ namespace Ipfs.Http
         {
             var data1 = new byte[] { 23, 24, 127 };
             var cid1 = ipfs.Block.PutAsync(data1, pin: true).Result;
-            var pins = ipfs.Pin.ListAsync().Result;
-            Assert.IsTrue(pins.Any(pin => pin == cid1.Id));
+            var pins = ipfs.Pin.ListAsync().ToEnumerable();
+            Assert.IsTrue(pins.Any(pin => pin.Cid == cid1.Id));
 
             var data2 = new byte[] { 123, 124, 27 };
             var cid2 = ipfs.Block.PutAsync(data2, pin: false).Result;
-            pins = ipfs.Pin.ListAsync().Result;
-            Assert.IsFalse(pins.Any(pin => pin == cid2.Id));
+            pins = ipfs.Pin.ListAsync().ToEnumerable();
+            Assert.IsFalse(pins.Any(pin => pin.Cid == cid2.Id));
         }
 
         [TestMethod]
@@ -106,13 +106,13 @@ namespace Ipfs.Http
         {
             var data1 = new MemoryStream(new byte[] { 23, 24, 127 });
             var cid1 = ipfs.Block.PutAsync(data1, pin: true).Result;
-            var pins = ipfs.Pin.ListAsync().Result;
-            Assert.IsTrue(pins.Any(pin => pin == cid1.Id));
+            var pins = ipfs.Pin.ListAsync().ToEnumerable();
+            Assert.IsTrue(pins.Any(pin => pin.Cid == cid1.Id));
 
             var data2 = new MemoryStream(new byte[] { 123, 124, 27 });
             var cid2 = ipfs.Block.PutAsync(data2, pin: false).Result;
-            pins = ipfs.Pin.ListAsync().Result;
-            Assert.IsFalse(pins.Any(pin => pin == cid2.Id));
+            pins = ipfs.Pin.ListAsync().ToEnumerable();
+            Assert.IsFalse(pins.Any(pin => pin.Cid == cid2.Id));
         }
 
         [TestMethod]

--- a/test/CoreApi/DagApiTest.cs
+++ b/test/CoreApi/DagApiTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Ipfs.Http
@@ -48,6 +49,64 @@ namespace Ipfs.Http
 
             var value = (string)await ipfs.Dag.GetAsync(id.Encode() + "/Last");
             Assert.AreEqual(expected.Last, value);
+        }
+
+        [TestMethod]
+        public async Task Import_Default_Pins_Roots()
+        {
+            var ipfs = TestFixture.Ipfs;
+
+            var node = await ipfs.FileSystem.AddTextAsync("car import default pin");
+            await using var car = await ipfs.Dag.ExportAsync(node.Id);
+
+            // ensure unpinned first
+            await ipfs.Pin.RemoveAsync(node.Id);
+
+            var result = await ipfs.Dag.ImportAsync(car, pinRoots: null, stats: false);
+            Assert.IsNotNull(result.Root);
+
+            var pins = await ipfs.Pin.ListAsync().ToArrayAsync();
+            Assert.IsTrue(pins.Any(p => p.Cid == node.Id));
+        }
+
+        [TestMethod]
+        public async Task Import_PinRoots_False_Does_Not_Pin()
+        {
+            var ipfs = TestFixture.Ipfs;
+
+            var node = await ipfs.FileSystem.AddTextAsync("car import nopin");
+            await using var car = await ipfs.Dag.ExportAsync(node.Id);
+
+            // ensure unpinned first
+            await ipfs.Pin.RemoveAsync(node.Id);
+
+            var result = await ipfs.Dag.ImportAsync(car, pinRoots: false, stats: false);
+            // Some Kubo versions emit no Root output when pin-roots=false; allow null.
+
+            var pins = await ipfs.Pin.ListAsync().ToArrayAsync();
+            Assert.IsFalse(pins.Any(p => p.Cid == node.Id));
+        }
+
+        [TestMethod]
+        public async Task Export_Then_Import_Roundtrip_Preserves_Root()
+        {
+            var ipfs = TestFixture.Ipfs;
+
+            var node = await ipfs.FileSystem.AddTextAsync("car export roundtrip");
+
+            // ensure unpinned first so import with pinRoots=true creates a new pin
+            try { await ipfs.Pin.RemoveAsync(node.Id); } catch { }
+
+            await using var car = await ipfs.Dag.ExportAsync(node.Id);
+            Assert.IsNotNull(car);
+
+            var result = await ipfs.Dag.ImportAsync(car, pinRoots: true, stats: false);
+            Assert.IsNotNull(result.Root);
+            Assert.AreEqual(node.Id.ToString(), result.Root!.Cid.ToString());
+
+            // Verify it is pinned now
+            var pins = await ipfs.Pin.ListAsync().ToArrayAsync();
+            Assert.IsTrue(pins.Any(p => p.Cid == node.Id));
         }
     }
 }

--- a/test/CoreApi/FileSystemApiTest.cs
+++ b/test/CoreApi/FileSystemApiTest.cs
@@ -95,8 +95,8 @@ namespace Ipfs.Http
             var data = new MemoryStream(new byte[] { 11, 22, 33 });
             var options = new AddFileOptions { Pin = false };
             var node = ipfs.FileSystem.AddAsync(data, "", options).Result;
-            var pins = ipfs.Pin.ListAsync().Result;
-            Assert.IsFalse(pins.Any(pin => pin == node.Id));
+            var pins = ipfs.Pin.ListAsync().ToEnumerable();
+            Assert.IsFalse(pins.Any(pin => pin.Cid == node.Id));
         }
 
         [TestMethod]

--- a/test/CoreApi/FileSystemApiTest.cs
+++ b/test/CoreApi/FileSystemApiTest.cs
@@ -125,6 +125,22 @@ namespace Ipfs.Http
         }
 
         [TestMethod]
+        public async Task Add_WithPinName_PinsNamed()
+        {
+            var ipfs = TestFixture.Ipfs;
+            var name = $"add-pin-{Guid.NewGuid()}";
+            var node = await ipfs.FileSystem.AddTextAsync("named pin via add", new AddFileOptions { Pin = true, PinName = name });
+
+            var items = await ipfs.Pin.ListAsync(new PinListOptions { Names = true }).ToArrayAsync();
+            var match = items.FirstOrDefault(i => i.Cid == node.Id);
+            Assert.IsNotNull(match, "Expected CID to be pinned");
+            Assert.AreEqual(name, match!.Name, "Expected pin name to match");
+
+            // cleanup
+            await ipfs.Pin.RemoveAsync(node.Id);
+        }
+
+        [TestMethod]
         public async Task GetTar_EmptyDirectory()
         {
             var ipfs = TestFixture.Ipfs;

--- a/test/CoreApi/PinApiTest.cs
+++ b/test/CoreApi/PinApiTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ipfs.CoreApi;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -17,13 +18,22 @@ namespace Ipfs.Http
         }
 
         [TestMethod]
+        public async Task List_WithType_All()
+        {
+            var ipfs = TestFixture.Ipfs;
+            var pins = await ipfs.Pin.ListAsync(PinType.All);
+            Assert.IsNotNull(pins);
+            Assert.IsTrue(pins.Count() > 0);
+        }
+
+        [TestMethod]
         public async Task Add_Remove()
         {
             var ipfs = TestFixture.Ipfs;
             var result = await ipfs.FileSystem.AddTextAsync("I am pinned");
             var id = result.Id;
 
-            var pins = await ipfs.Pin.AddAsync(id);
+            var pins = await ipfs.Pin.AddAsync(id, new PinAddOptions { Recursive = true });
             Assert.IsTrue(pins.Any(pin => pin == id));
             var all = await ipfs.Pin.ListAsync();
             Assert.IsTrue(all.Any(pin => pin == id));
@@ -32,6 +42,39 @@ namespace Ipfs.Http
             Assert.IsTrue(pins.Any(pin => pin == id));
             all = await ipfs.Pin.ListAsync();
             Assert.IsFalse(all.Any(pin => pin == id));
+        }
+
+        [TestMethod]
+        public async Task Add_WithName()
+        {
+            var ipfs = TestFixture.Ipfs;
+            var result = await ipfs.FileSystem.AddTextAsync("I am pinned with a name");
+            var id = result.Id;
+            var name = $"tdd-{System.Guid.NewGuid()}";
+
+            var pins = await ipfs.Pin.AddAsync(id, new PinAddOptions { Name = name, Recursive = true });
+            Assert.IsTrue(pins.Any(pin => pin == id));
+
+            var all = await ipfs.Pin.ListAsync();
+            Assert.IsTrue(all.Any(pin => pin == id));
+
+            // cleanup
+            await ipfs.Pin.RemoveAsync(id);
+        }
+
+        [TestMethod]
+        public async Task Add_WithName_NonRecursive()
+        {
+            var ipfs = TestFixture.Ipfs;
+            var result = await ipfs.FileSystem.AddTextAsync("I am pinned non-recursive with a name", new Ipfs.CoreApi.AddFileOptions { Pin = false });
+            var id = result.Id;
+            var name = $"tdd-nr-{System.Guid.NewGuid()}";
+
+            var pins = await ipfs.Pin.AddAsync(id, new PinAddOptions { Name = name, Recursive = false });
+            Assert.IsTrue(pins.Any(pin => pin == id));
+
+            // cleanup
+            await ipfs.Pin.RemoveAsync(id, recursive: false);
         }
 
     }

--- a/test/CoreApi/PinApiTest.cs
+++ b/test/CoreApi/PinApiTest.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Ipfs.CoreApi;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -12,18 +14,18 @@ namespace Ipfs.Http
         public void List()
         {
             var ipfs = TestFixture.Ipfs;
-            var pins = ipfs.Pin.ListAsync().Result;
+            var pins = ipfs.Pin.ListAsync().ToEnumerable().ToArray();
             Assert.IsNotNull(pins);
-            Assert.IsTrue(pins.Count() > 0);
+            Assert.IsTrue(pins.Length > 0);
         }
 
         [TestMethod]
         public async Task List_WithType_All()
         {
             var ipfs = TestFixture.Ipfs;
-            var pins = await ipfs.Pin.ListAsync(PinType.All);
+            var pins = await ipfs.Pin.ListAsync(PinType.All).ToArrayAsync();
             Assert.IsNotNull(pins);
-            Assert.IsTrue(pins.Count() > 0);
+            Assert.IsTrue(pins.Length > 0);
         }
 
         [TestMethod]
@@ -35,13 +37,13 @@ namespace Ipfs.Http
 
             var pins = await ipfs.Pin.AddAsync(id, new PinAddOptions { Recursive = true });
             Assert.IsTrue(pins.Any(pin => pin == id));
-            var all = await ipfs.Pin.ListAsync();
-            Assert.IsTrue(all.Any(pin => pin == id));
+            var all = await ipfs.Pin.ListAsync().ToArrayAsync();
+            Assert.IsTrue(all.Any(pin => pin.Cid == id));
 
-            pins = await ipfs.Pin.RemoveAsync(id);
-            Assert.IsTrue(pins.Any(pin => pin == id));
-            all = await ipfs.Pin.ListAsync();
-            Assert.IsFalse(all.Any(pin => pin == id));
+            var removed = await ipfs.Pin.RemoveAsync(id);
+            Assert.IsTrue(removed.Any(pin => pin == id));
+            all = await ipfs.Pin.ListAsync().ToArrayAsync();
+            Assert.IsFalse(all.Any(pin => pin.Cid == id));
         }
 
         [TestMethod]
@@ -55,8 +57,8 @@ namespace Ipfs.Http
             var pins = await ipfs.Pin.AddAsync(id, new PinAddOptions { Name = name, Recursive = true });
             Assert.IsTrue(pins.Any(pin => pin == id));
 
-            var all = await ipfs.Pin.ListAsync();
-            Assert.IsTrue(all.Any(pin => pin == id));
+            var all = await ipfs.Pin.ListAsync().ToArrayAsync();
+            Assert.IsTrue(all.Any(pin => pin.Cid == id));
 
             // cleanup
             await ipfs.Pin.RemoveAsync(id);
@@ -75,6 +77,64 @@ namespace Ipfs.Http
 
             // cleanup
             await ipfs.Pin.RemoveAsync(id, recursive: false);
+        }
+
+        [TestMethod]
+        public async Task Add_WithProgress_Reports_And_Pins()
+        {
+            var ipfs = TestFixture.Ipfs;
+            // Create a larger object (>256 KiB) to ensure multiple blocks
+            var data = new byte[300_000];
+            var node = await ipfs.FileSystem.AddAsync(new System.IO.MemoryStream(data, writable: false), "big.bin", new Ipfs.CoreApi.AddFileOptions { Pin = false });
+            var id = node.Id;
+
+            var progressValues = new List<int>();
+            var progress = new Progress<BlocksPinnedProgress>(p => progressValues.Add(p.BlocksPinned));
+
+            var pins = await ipfs.Pin.AddAsync(id, new PinAddOptions { Recursive = true }, progress);
+
+            Assert.IsTrue(pins.Any(pin => pin == id), "Expected returned pins to contain the root CID");
+            Assert.IsTrue(progressValues.Count >= 1, "Expected at least one progress report");
+            Assert.IsTrue(progressValues[progressValues.Count - 1] >= 1, "Expected final progress to be >= 1");
+            // Monotonic non-decreasing
+            for (int i = 1; i < progressValues.Count; i++)
+            {
+                Assert.IsTrue(progressValues[i] >= progressValues[i - 1], "Progress should be non-decreasing");
+            }
+
+            // cleanup
+            await ipfs.Pin.RemoveAsync(id);
+        }
+
+        [TestMethod]
+        public async Task List_NonStreaming_Default()
+        {
+            var ipfs = TestFixture.Ipfs;
+            var items = await ipfs.Pin.ListAsync(new PinListOptions { Stream = false }).ToArrayAsync();
+            Assert.IsTrue(items.Length > 0);
+            Assert.IsTrue(items.All(i => i.Cid != null));
+        }
+
+        [TestMethod]
+        public async Task List_Streaming_WithNames()
+        {
+            var ipfs = TestFixture.Ipfs;
+            // Ensure at least one named pin exists
+            var n = await ipfs.FileSystem.AddTextAsync("named pin", new Ipfs.CoreApi.AddFileOptions { Pin = false });
+            var id = n.Id;
+            var name = $"tdd-name-{Guid.NewGuid()}";
+            await ipfs.Pin.AddAsync(id, new PinAddOptions { Name = name });
+
+            var items = new List<PinListItem>();
+            await foreach (var item in ipfs.Pin.ListAsync(new PinListOptions { Stream = true, Names = true }))
+            {
+                items.Add(item);
+            }
+            Assert.IsTrue(items.Count > 0);
+            Assert.IsTrue(items.Any(i => i.Cid == id));
+
+            // cleanup
+            await ipfs.Pin.RemoveAsync(id);
         }
 
     }

--- a/test/IpfsHttpClientTests.csproj
+++ b/test/IpfsHttpClientTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="OwlCore.Kubo" Version="0.21.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestFixture.cs
+++ b/test/TestFixture.cs
@@ -1,14 +1,102 @@
-﻿namespace Ipfs.Http
-{
-    public static class TestFixture
-    {
-        /// <summary>
-        ///   Fiddler cannot see localhost traffic because .Net bypasses the network stack for localhost/127.0.0.1. 
-        ///   By using "127.0.0.1." (note trailing dot) fiddler will receive the traffic and if its not running
-        ///   the localhost will get it!
-        /// </summary>
-        //IpfsClient.DefaultApiUri = new Uri("http://127.0.0.1.:5001");
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using OwlCore.Kubo;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OwlCore.Storage.System.IO;
+using OwlCore.Storage;
+using System.Diagnostics;
 
-        public static IpfsClient Ipfs = new IpfsClient();
+namespace Ipfs.Http
+{
+    [TestClass]
+    public class TestFixture
+    {
+        // Publicly accessible client and API URI for tests.
+        public static IpfsClient Ipfs { get; private set; } = null!;
+        public static Uri? ApiUri { get; private set; }
+    private static KuboBootstrapper? Node;
+
+        [AssemblyInitialize]
+        public static void AssemblyInit(TestContext context)
+        {
+            try
+            {
+                OwlCore.Diagnostics.Logger.MessageReceived += (sender, args) => context.WriteLine(args.Message);
+
+                // Ensure the test runner has provided a deployment directory to use for working folders.
+                Assert.IsNotNull(context.DeploymentDirectory);
+
+                // Create a working folder and start a fresh Kubo node with default bootstrap peers.
+                var workingFolder = SafeCreateWorkingFolder(new SystemFolder(context.DeploymentDirectory), typeof(TestFixture).Namespace ?? "test").GetAwaiter().GetResult();
+
+                // Use non-default ports to avoid conflicts with any locally running node.
+                int apiPort = 11501;
+                int gatewayPort = 18080;
+
+                Node = CreateNodeAsync(workingFolder, "kubo-node", apiPort, gatewayPort).GetAwaiter().GetResult();
+                ApiUri = Node.ApiUri;
+                Ipfs = new IpfsClient(ApiUri.ToString());
+
+                context?.WriteLine($"Connected to existing Kubo node: {ApiUri}");
+            }
+            catch (Exception ex)
+            {
+                context?.WriteLine($"Kubo bootstrapper failed to start: {ex}");
+                throw;
+            }
+        }
+
+        public static async Task<KuboBootstrapper> CreateNodeAsync(SystemFolder workingDirectory, string nodeRepoName, int apiPort, int gatewayPort)
+        {
+            var nodeRepo = (SystemFolder)await workingDirectory.CreateFolderAsync(nodeRepoName, overwrite: true);
+
+            var node = new KuboBootstrapper(nodeRepo.Path)
+            {
+                ApiUri = new Uri($"http://127.0.0.1:{apiPort}"),
+                GatewayUri = new Uri($"http://127.0.0.1:{gatewayPort}"),
+                RoutingMode = DhtRoutingMode.AutoClient,
+                LaunchConflictMode = BootstrapLaunchConflictMode.Relaunch,
+                BinaryWorkingFolder = workingDirectory,
+                EnableFilestore = true,
+            };
+
+            OwlCore.Diagnostics.Logger.LogInformation($"Starting node {nodeRepoName}\n");
+
+            await node.StartAsync().ConfigureAwait(false);
+            await node.Client.IdAsync().ConfigureAwait(false);
+
+            Debug.Assert(node.Process != null);
+            return node;
+        }
+
+        public static async Task<SystemFolder> SafeCreateWorkingFolder(SystemFolder rootFolder, string name)
+        {
+            var testTempRoot = (SystemFolder)await rootFolder.CreateFolderAsync(name, overwrite: false);
+            await SetAllFileAttributesRecursive(testTempRoot, attributes => attributes & ~FileAttributes.ReadOnly).ConfigureAwait(false);
+
+            // Delete and recreate the folder.
+            return (SystemFolder)await rootFolder.CreateFolderAsync(name, overwrite: true).ConfigureAwait(false);
+        }
+
+        public static async Task SetAllFileAttributesRecursive(SystemFolder rootFolder, Func<FileAttributes, FileAttributes> transform)
+        {
+            await foreach (SystemFile file in rootFolder.GetFilesAsync())
+                file.Info.Attributes = transform(file.Info.Attributes);
+
+            await foreach (SystemFolder folder in rootFolder.GetFoldersAsync())
+                await SetAllFileAttributesRecursive(folder, transform).ConfigureAwait(false);
+        }
+
+        [AssemblyCleanup]
+        public static void AssemblyCleanup()
+        {
+            try
+            {
+                Node?.Dispose();
+            }
+            catch { }
+        }
     }
 }

--- a/test/TestFixture.cs
+++ b/test/TestFixture.cs
@@ -16,7 +16,7 @@ namespace Ipfs.Http
         // Publicly accessible client and API URI for tests.
         public static IpfsClient Ipfs { get; private set; } = null!;
         public static Uri? ApiUri { get; private set; }
-    private static KuboBootstrapper? Node;
+        public static KuboBootstrapper? Node;
 
         [AssemblyInitialize]
         public static void AssemblyInit(TestContext context)

--- a/test/TlsReproTest.cs
+++ b/test/TlsReproTest.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace Ipfs.Http
+{
+    [TestClass]
+    public class TlsReproTest
+    {
+        [TestMethod]
+        public void Real_Tls_MultiAddress_Should_Fail()
+        {
+            // Real multiaddr from long-running node that contains TLS
+            var realTlsAddr = "/dns4/45-86-153-40.k51qzi5uqu5dhssh49wibkxi3yw56ihw9uo7cxctyiqbfxpodudqo09swsxp1s.libp2p.direct/tcp/4001/tls/ws/p2p/12D3KooWEBaJd7msGiDjA5ATyMpVSEgja4xc6FXkxddaSM9DtHCT/p2p-circuit/p2p/12D3KooWEPx5LSWNGRtQFweBG9KMsfNjdogoeRisF9cU2s5RcrsJ";
+            
+            var addr = new MultiAddress(realTlsAddr);
+            OwlCore.Diagnostics.Logger.LogInformation($"Successfully parsed TLS multiaddr: {addr}");
+            
+            // Check if it contains the protocols we expect
+            var protocols = addr.Protocols.ToList();
+            OwlCore.Diagnostics.Logger.LogInformation($"Protocol count: {protocols.Count}");
+            
+            foreach(var protocol in protocols)
+            {
+                OwlCore.Diagnostics.Logger.LogInformation($"Protocol: {protocol.Name} (code: {protocol.Code})");
+            }
+            
+            Assert.IsNotNull(addr);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implementation of https://github.com/ipfs-shipyard/net-ipfs-core/pull/53

This PR was prepared by checking Kubo version changelogs 0.9.0 through 0.37.0 for any mentioned changes related to pinning, then these findings were cross-referenced with our existing codebase to identify the changes needed.

The IPinApi and a few other APIs that touch pinning (`add`, `dag import` etc.) have been brought fully in line with the (as yet unreleased) Kubo 0.37.0:
- Introduced an overload for IProgress/IAsyncEnumerable-based pin add progress reporting while preserving non-progress flow.
- [breaking] Refactored IPinApi.ListPinsAsync. Return type `Task<IEnumerable<Cid>>` is now `IAsyncEnumerable<PinListItem>`, and a `PinListOptions` param was added containing name filters, recurse and stream options.
- [breaking] Updated pin add to accept `PinAddOptions` (replaces the `recursive` boolean parameter).
    - Support named pins: added `Name` support (PinAddOptions/PinListItem) and optional name filter in `PinListOptions`.
- In the HTTP library, we've replaced JObject token handling with typed records/DTOs.
- We now respect Kubo defaults for DAG import (pin-roots default) and switch DAG export to POST.
- Add remarks that unpinning does not delete blocks; GC reclaims storage.

## Changes (core)
- Pin API
  - New `PinListOptions` and `PinListItem` domain model (list streaming and filtering preserved at the core surface).
  - `IPinApi.ListAsync(...)` unified as IAsyncEnumerable; added overload with `PinListOptions`.
  - `IPinApi.AddAsync(...)` updated to take `PinAddOptions` (replaces the `recursive` boolean); added overload with `IProgress<BlocksPinnedProgress>`.
  - Named pins: `PinAddOptions.Name`; `PinListItem.Name`; `PinListOptions.Name` filter and `Names` toggle.
  - Documentation: `RemoveAsync` remarks clarify that unpinning does not delete blocks; GC required to reclaim.
- DAG API
  - `DagApi.ImportAsync(...)`: omit `pin-roots` when null so Kubo default applies (roots pinned by default).
  - Model: `CarImportOutput` with `Root` and optional `Stats`.
 - File add options
   - `AddFileOptions`: added `PinName`; minor docs/option clarifications. In downstream HTTP client wiring, fixed `hash` parameter formatting and corrected `fscache` flag mapping.

## Tests
- Pin list: streaming and non-streaming coverage.
- Pin add: progress and non-progress coverage.
- Named pins (when supported by daemon): list names and name filtering covered at the HTTP client layer.
- DAG import/export (in http client):
  - Default pin roots respected, pin-roots=false does not pin; export/import roundtrip preserves root CID.

## Compatibility / Notes
- Kubo<=0.36.x lacks `--pin-name`; net-ipfs-core exposes property but behavior depends on daemon version.
- Some Kubo versions may not emit a dag import root line when `pin-roots=false`; the client tolerates this by returning an empty object.
- Breaking changes (core):
  - `IPinApi.ListAsync(...)` now returns `IAsyncEnumerable<PinListItem>` (previously returned a materialized collection of CIDs); also added `ListAsync(PinListOptions)`.
  - `IPinApi.AddAsync(...)` signature changed to use `PinAddOptions` (replaces the `recursive` bool parameter).
- Non-breaking additions:
  - New overload `IPinApi.AddAsync(..., IProgress<BlocksPinnedProgress> progress, ...)`.
  - `AddFileOptions.PinName` is additive and forward-compatible (effect depends on daemon version).
  - New types: `PinListOptions`, `PinListItem`.
  - Flag alias parity for `--name/-n` is provided at the HTTP client layer; core exposes the filter option.


