### PR TITLE
Use .NET 9 SDK in CI and net9.0 TFM in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Install .NET 6 SDK
+      - name: Install .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.201'
+          dotnet-version: '9.0.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,12 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET
+
+    - name: Install .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: '9.0.x'
+
     - name: Restore dependencies
       run: dotnet restore
+      
     - name: Build
       run: dotnet build --no-restore -p:Configuration=Release
     

--- a/test/IpfsHttpClientTests.csproj
+++ b/test/IpfsHttpClientTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net6.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+	  <TargetFrameworks>net9.0</TargetFrameworks>
+    <LangVersion>13.0</LangVersion>
 
     <IsPackable>false</IsPackable>
     <DebugType>full</DebugType>


### PR DESCRIPTION
Update GitHub Actions runners to use .NET 9 SDK and retarget tests to net9.0.

This resolves CI failures from PolySharp (POLYSPCFG0001) requiring Roslyn 4.3+ on older SDKs.

From https://github.com/ipfs-shipyard/net-ipfs-http-client/actions/runs/17017184933/job/48241376302#step:4:25:
```
Error: /home/runner/.nuget/packages/polysharp/1.14.1/buildTransitive/PolySharp.targets(45,5): error POLYSPCFG0001: The PolySharp source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. PolySharp requires the source generators to run in order to generate polyfills, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.3 or greater) or .NET SDK version (.NET 6.0.400 SDK or greater). [/home/runner/work/net-ipfs-http-client/net-ipfs-http-client/src/IpfsHttpClient.csproj]
```

- build.yml: setup-dotnet 9.0.x
- publish.yml: setup-dotnet 9.0.x
- test/IpfsHttpClientTests.csproj: TargetFrameworks=net9.0

No product code changes.