### PR TITLE
Release 0.7.0. Pin API alignment, dep updates, misc fixes.

### DIFF
--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -9,7 +9,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- https://semver.org/spec/v2.0.0.html -->
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <LangVersion>12.0</LangVersion>
 
@@ -41,6 +41,30 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb;$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PackageReleaseNotes>
+--- 0.7.0 ---
+[Breaking]
+Pin API aligned with modern Kubo:
+IPinApi.ListAsync now returns IAsyncEnumerable{PinListItem} added ListAsync(PinListOptions).
+IPinApi.AddAsync now takes PinAddOptions (replaces the recursive boolean parameter).
+DAG API: Use POST for export; respect Kubo default for dag import (pin-roots default).
+
+[New]
+Pin add progress via IProgress{BlocksPinnedProgress} overload.
+Named pins support: PinAddOptions.Name for add; PinListItem.Name; PinListOptions.Name filter (and Names toggle).
+AddFileOptions.PinName mapped to pin-name in file adds.
+
+[Improvements]
+HTTP client parses pin responses using typed records/DTOs (replaces JObject handling).
+Honor AddFileOptions.Pin during file add (pin=true/false).
+DAG import tolerant to missing lines on some Kubo versions; export/import roundtrip coverage.
+Fixed hash parameter formatting and fscache flag mapping in HTTP layer.
+
+[Dependencies]
+Updated to IpfsShipyard.Ipfs.Core 0.8.0.
+
+[CI]
+Use .NET 9 SDK in CI and retarget tests to net9.0; resolves PolySharp POLYSPCFG0001 on older SDKs.
+
 --- 0.6.0 ---
 [Breaking]
 Fixed WebRTC-Direct support added in Kubo 0.30.0.


### PR DESCRIPTION
[Breaking]
Pin API aligned with modern Kubo:
IPinApi.ListAsync now returns IAsyncEnumerable{PinListItem} added ListAsync(PinListOptions).
IPinApi.AddAsync now takes PinAddOptions (replaces the recursive boolean parameter).
DAG API: Use POST for export; respect Kubo default for dag import (pin-roots default).

[New]
Pin add progress via IProgress{BlocksPinnedProgress} overload.
Named pins support: PinAddOptions.Name for add; PinListItem.Name; PinListOptions.Name filter (and Names toggle).
AddFileOptions.PinName mapped to pin-name in file adds.

[Improvements]
HTTP client parses pin responses using typed records/DTOs (replaces JObject handling).
Honor AddFileOptions.Pin during file add (pin=true/false).
DAG import tolerant to missing lines on some Kubo versions; export/import roundtrip coverage.
Fixed hash parameter formatting and fscache flag mapping in HTTP layer.

[Dependencies]
Updated to IpfsShipyard.Ipfs.Core 0.8.0.

[CI]
Use .NET 9 SDK in CI and retarget tests to net9.0; resolves PolySharp POLYSPCFG0001 on older SDKs.